### PR TITLE
minor patches for RDF compliance

### DIFF
--- a/data/convert_to_triples.R
+++ b/data/convert_to_triples.R
@@ -348,7 +348,7 @@ triples_df %>%
          graph = ".") %>% # quads have a fourth column, usually "."
   filter(Object != "<NA>", Subject != "<NA>", Predicate != "<NA>") %>% # we have some NAs sneaking in as URIs
   mutate(Object = gsub("\\", "\\\\", Object, fixed=TRUE)) %>% # escape backslashes :(
-  write_delim("data/traits.nq", col_names=FALSE, escape="none", quote="none")
+  write_delim("data/ADP.nq", col_names=FALSE, escape="none", quote="none")
 
 # prove this parses correctly
 library(rdflib)

--- a/data/convert_to_triples.R
+++ b/data/convert_to_triples.R
@@ -6,10 +6,10 @@ library(stringr)
 read_csv("data/APD_references.csv") %>%
   mutate(
     Entity = paste0("<", Entity, ">"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    identifier = paste0("'", identifier, "'", "^^[xsd:string]"),
-    citation = paste0("'", citation, "'", "@en"),
-    title = paste0("'", title, "'", "@en")
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    identifier = paste0("\"", identifier, "\"", "^^<xsd:string>"),
+    citation = paste0("\"", citation, "\"", "@en"),
+    title = paste0("\"", title, "\"", "@en")
   ) %>%
   rename(
     Subject = Entity,
@@ -28,8 +28,8 @@ read_csv("data/APD_references.csv") %>%
 read_csv("data/APD_reviewers.csv") %>%
   mutate(
     Entity = paste0("<", Entity, ">"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    ORCID = paste0("'", ORCID, "'", "^^[xsd:string]")
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    ORCID = paste0("\"", ORCID, "\"", "^^<xsd:string>")
   ) %>%
   rename(
     Subject = Entity,
@@ -49,10 +49,10 @@ read_csv("data/APD_units.csv") %>%
   select(Entity, label, description, SI_code, UCUM_code) %>%
   mutate(
     Entity = paste0("<", Entity, ">"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    description = ifelse(!is.na(description), paste0("'", description, "'", "@en"), NA),
-    SI_code = ifelse(!is.na(SI_code), paste0("'", SI_code, "'", "^^[xsd:string]"), NA),
-    UCUM_code = ifelse(!is.na(UCUM_code), paste0("'", UCUM_code, "'", "^^[xsd:string]"), NA)
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    description = ifelse(!is.na(description), paste0("\"", description, "\"", "@en"), NA),
+    SI_code = ifelse(!is.na(SI_code), paste0("\"", SI_code, "\"", "^^<xsd:string>"), NA),
+    UCUM_code = ifelse(!is.na(UCUM_code), paste0("\"", UCUM_code, "\"", "^^<xsd:string>"), NA)
   ) %>%
   rename(
     Subject = Entity,
@@ -75,8 +75,8 @@ read_csv("data/APD_categorical_values.csv") %>%
   select(Entity, label, description, trait_name) %>%
   mutate(
     Entity = paste0("<https://github.com/traitecoevo/", Entity, ">"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    description = paste0("'", description, "'", "@en"),
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    description = paste0("\"", description, "\"", "@en"),
     Parent = traits$identifier[match(trait_name, traits$trait)],
     Parent = paste0("<https://github.com/traitecoevo/", Parent, ">")
   ) %>%
@@ -98,8 +98,8 @@ read_csv("data/APD_trait_hierarchy.csv") %>%
     select(Entity, label, description, Parent, exactMatch) %>%
     mutate(
       Entity = paste0("<", Entity, ">"),
-      label = paste0("'", label, "'", "^^[xsd:string]"),
-      description = paste0("'", description, "'", "@en"),
+      label = paste0("\"", label, "\"", "^^<xsd:string>"),
+      description = paste0("\"", description, "\"", "@en"),
       Parent = paste0("<", Parent, ">"),
       exactMatch = ifelse(!is.na(exactMatch), paste0("<", exactMatch, ">"), NA)
     ) %>%
@@ -122,11 +122,11 @@ read_csv("data/ontology_links.csv") %>%
   select(Entity, label, description, identifier, inScheme, prefix) %>%
   mutate(
     Entity = paste0("<", Entity, ">"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    description = ifelse(!is.na(description), paste0("'", description, "'", "@en"), NA),
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    description = ifelse(!is.na(description), paste0("\"", description, "\"", "@en"), NA),
     identifier = str_replace(identifier, "^[:alpha:]+\\:", ""),
-    identifier = paste0("'", identifier, "'", "^^[xsd:string]"),
-    inScheme = paste0("'", inScheme, "'", "^^[xsd:string]")
+    identifier = paste0("\"", identifier, "\"", "^^<xsd:string>"),
+    inScheme = paste0("\"", inScheme, "\"", "^^<xsd:string>")
   ) %>%
   select(-prefix) %>%
   rename(
@@ -150,29 +150,30 @@ read_csv("data/APD_references.csv") -> references
 read_csv("data/APD_units.csv") -> units_csv
 read_csv("data/APD_trait_hierarchy.csv") -> hierarchy
 
-read_csv("data/APD_traits.csv") %>%
+read_csv("data/APD_traits.csv") %>% 
+  mutate(across(where(is.character), \(x) stringr::str_replace_all(x, "\"", "'"))) |>
   mutate(
     Entity =  paste0("<https://github.com/traitecoevo/", identifier, ">"),
-    trait = paste0("'", trait, "'", "^^[xsd:string]"),
-    label = paste0("'", label, "'", "^^[xsd:string]"),
-    description_encoded = ifelse(!is.na(description_encoded), paste0("'", description_encoded, "'", "@en"), NA),
-    description = ifelse(!is.na(description), paste0("'", description, "'", "@en"), NA),
-    comments = ifelse(!is.na(comments), paste0("'", comments, "'", "@en"), NA),
-    inScheme = paste0("'", inScheme, "'", "^^[xsd:string]"),
+    trait = paste0("\"", trait, "\"", "^^<xsd:string>"),
+    label = paste0("\"", label, "\"", "^^<xsd:string>"),
+    description_encoded = ifelse(!is.na(description_encoded), paste0("\"", description_encoded, "\"", "@en"), NA),
+    description = ifelse(!is.na(description), paste0("\"", description, "\"", "@en"), NA),
+    comments = ifelse(!is.na(comments), paste0("\"", comments, "\"", "@en"), NA),
+    inScheme = paste0("\"", inScheme, "\"", "^^<xsd:string>"),
     type = paste0("<", ontology_links$Entity[match(type, ontology_links$identifier)], ">"),
-    min = ifelse(!is.na(min), paste0("'", min, "'", "^^[xsd:double]"), NA),
-    max = ifelse(!is.na(max), paste0("'", max, "'", "^^[xsd:double]"), NA),
-    units = ifelse(!is.na(units), paste0("'", units, "'", "^^[xsd:string]"), NA),
-    units_UCUM = ifelse(!is.na(units_UCUM), paste0("'", units_UCUM, "'", "^^[xsd:string]"), NA),
+    min = ifelse(!is.na(min), paste0("\"", min, "\"", "^^<xsd:double>"), NA),
+    max = ifelse(!is.na(max), paste0("\"", max, "\"", "^^<xsd:double>"), NA),
+    units = ifelse(!is.na(units), paste0("\"", units, "\"", "^^<xsd:string>"), NA),
+    units_UCUM = ifelse(!is.na(units_UCUM), paste0("\"", units_UCUM, "\"", "^^<xsd:string>"), NA),
     units_uom = ifelse(!is.na(units_uom), paste0("<", units_csv$Entity[match(units_uom, units_csv$label)], ">"), NA),
     category_1 = ifelse(!is.na(category_1), paste0("<", hierarchy$Entity[match(category_1, hierarchy$label)], ">"), NA),
     category_2 = ifelse(!is.na(category_2), paste0("<", hierarchy$Entity[match(category_1, hierarchy$label)], ">"), NA),
     category_3 = ifelse(!is.na(category_3), paste0("<", hierarchy$Entity[match(category_1, hierarchy$label)], ">"), NA),
     category_4 = ifelse(!is.na(category_4), paste0("<", hierarchy$Entity[match(category_1, hierarchy$label)], ">"), NA),
-    created = ifelse(!is.na(created), paste0("'", created, "'", "^^[xsd:date]"), NA),
-    modified = ifelse(!is.na(modified), paste0("'", modified, "'", "^^[xsd:date]"), NA),
-    deprecated_trait_name = ifelse(!is.na(deprecated_trait_name), paste0("'", deprecated_trait_name, "'", "^^[xsd:string]"), NA),
-    constraints = ifelse(!is.na(constraints), paste0("'", constraints, "'", "@en"), NA),
+    created = ifelse(!is.na(created), paste0("\"", created, "\"", "^^<xsd:date>"), NA),
+    modified = ifelse(!is.na(modified), paste0("\"", modified, "\"", "^^<xsd:date>"), NA),
+    deprecated_trait_name = ifelse(!is.na(deprecated_trait_name), paste0("\"", deprecated_trait_name, "\"", "^^<xsd:string>"), NA),
+    constraints = ifelse(!is.na(constraints), paste0("\"", constraints, "\"", "@en"), NA),
     structure_1 = ifelse(!is.na(structure_1), paste0("<", ontology_links$Entity[match(structure_1, ontology_links$identifier)], ">"), NA),
     structure_2 = ifelse(!is.na(structure_2), paste0("<", ontology_links$Entity[match(structure_2, ontology_links$identifier)], ">"), NA),
     structure_3 = ifelse(!is.na(structure_3), paste0("<", ontology_links$Entity[match(structure_3, ontology_links$identifier)], ">"), NA),
@@ -211,27 +212,27 @@ read_csv("data/APD_traits.csv") %>%
     close_other1 = ifelse(!is.na(close_other1), paste0("<", ontology_links$Entity[match(close_other1, ontology_links$identifier)], ">"), NA),
     close_other2 = ifelse(!is.na(close_other2), paste0("<", ontology_links$Entity[match(close_other2, ontology_links$identifier)], ">"), NA),
     related_other = ifelse(!is.na(related_other), paste0("<", ontology_links$Entity[match(related_other, ontology_links$identifier)], ">"), NA),
-    exact_TOP = ifelse(!is.na(exact_TOP), paste0("'", exact_TOP, "'", "^^[xsd:string]"), NA),
-    close_TOP = ifelse(!is.na(close_TOP), paste0("'", close_TOP, "'", "^^[xsd:string]"), NA),
-    related_TOP = ifelse(!is.na(related_TOP), paste0("'", related_TOP, "'", "^^[xsd:string]"), NA),
-    related_TOP2 = ifelse(!is.na(related_TOP2), paste0("'", related_TOP2, "'", "^^[xsd:string]"), NA),
-    exact_TRY = ifelse(!is.na(exact_TRY), paste0("'", exact_TRY, "'", "^^[xsd:string]"), NA),
-    close_TRY = ifelse(!is.na(close_TRY), paste0("'", close_TRY, "'", "^^[xsd:string]"), NA),
-    related_TRY = ifelse(!is.na(related_TRY), paste0("'", related_TRY, "'", "^^[xsd:string]"), NA),
-    exact_LEDA = ifelse(!is.na(exact_LEDA), paste0("'", exact_LEDA, "'", "^^[xsd:string]"), NA),
-    close_LEDA = ifelse(!is.na(close_LEDA), paste0("'", close_LEDA, "'", "^^[xsd:string]"), NA),
-    related_LEDA = ifelse(!is.na(related_LEDA), paste0("'", related_LEDA, "'", "^^[xsd:string]"), NA),
-    exact_GIFT = ifelse(!is.na(exact_GIFT), paste0("'", exact_GIFT, "'", "^^[xsd:string]"), NA),
-    close_GIFT = ifelse(!is.na(close_GIFT), paste0("'", close_GIFT, "'", "^^[xsd:string]"), NA),
-    related_GIFT = ifelse(!is.na(related_GIFT), paste0("'", related_GIFT, "'", "^^[xsd:string]"), NA),
-    exact_BIEN = ifelse(!is.na(exact_BIEN), paste0("'", exact_BIEN, "'", "^^[xsd:string]"), NA),
-    close_BIEN = ifelse(!is.na(close_BIEN), paste0("'", close_BIEN, "'", "^^[xsd:string]"), NA),
-    related_BIEN = ifelse(!is.na(related_BIEN), paste0("'", related_BIEN, "'", "^^[xsd:string]"), NA),
-    exact_BROT = ifelse(!is.na(exact_BROT), paste0("'", exact_BROT, "'", "^^[xsd:string]"), NA),
-    close_BROT = ifelse(!is.na(close_BROT), paste0("'", close_BROT, "'", "^^[xsd:string]"), NA),
-    related_BROT = ifelse(!is.na(related_BROT), paste0("'", related_BROT, "'", "^^[xsd:string]"), NA),
-    PalmTraits_exact = ifelse(!is.na(PalmTraits_exact), paste0("'", PalmTraits_exact, "'", "^^[xsd:string]"), NA),
-    PalmTraits_close = ifelse(!is.na(PalmTraits_close), paste0("'", PalmTraits_close, "'", "^^[xsd:string]"), NA)
+    exact_TOP = ifelse(!is.na(exact_TOP), paste0("\"", exact_TOP, "\"", "^^<xsd:string>"), NA),
+    close_TOP = ifelse(!is.na(close_TOP), paste0("\"", close_TOP, "\"", "^^<xsd:string>"), NA),
+    related_TOP = ifelse(!is.na(related_TOP), paste0("\"", related_TOP, "\"", "^^<xsd:string>"), NA),
+    related_TOP2 = ifelse(!is.na(related_TOP2), paste0("\"", related_TOP2, "\"", "^^<xsd:string>"), NA),
+    exact_TRY = ifelse(!is.na(exact_TRY), paste0("\"", exact_TRY, "\"", "^^<xsd:string>"), NA),
+    close_TRY = ifelse(!is.na(close_TRY), paste0("\"", close_TRY, "\"", "^^<xsd:string>"), NA),
+    related_TRY = ifelse(!is.na(related_TRY), paste0("\"", related_TRY, "\"", "^^<xsd:string>"), NA),
+    exact_LEDA = ifelse(!is.na(exact_LEDA), paste0("\"", exact_LEDA, "\"", "^^<xsd:string>"), NA),
+    close_LEDA = ifelse(!is.na(close_LEDA), paste0("\"", close_LEDA, "\"", "^^<xsd:string>"), NA),
+    related_LEDA = ifelse(!is.na(related_LEDA), paste0("\"", related_LEDA, "\"", "^^<xsd:string>"), NA),
+    exact_GIFT = ifelse(!is.na(exact_GIFT), paste0("\"", exact_GIFT, "\"", "^^<xsd:string>"), NA),
+    close_GIFT = ifelse(!is.na(close_GIFT), paste0("\"", close_GIFT, "\"", "^^<xsd:string>"), NA),
+    related_GIFT = ifelse(!is.na(related_GIFT), paste0("\"", related_GIFT, "\"", "^^<xsd:string>"), NA),
+    exact_BIEN = ifelse(!is.na(exact_BIEN), paste0("\"", exact_BIEN, "\"", "^^<xsd:string>"), NA),
+    close_BIEN = ifelse(!is.na(close_BIEN), paste0("\"", close_BIEN, "\"", "^^<xsd:string>"), NA),
+    related_BIEN = ifelse(!is.na(related_BIEN), paste0("\"", related_BIEN, "\"", "^^<xsd:string>"), NA),
+    exact_BROT = ifelse(!is.na(exact_BROT), paste0("\"", exact_BROT, "\"", "^^<xsd:string>"), NA),
+    close_BROT = ifelse(!is.na(close_BROT), paste0("\"", close_BROT, "\"", "^^<xsd:string>"), NA),
+    related_BROT = ifelse(!is.na(related_BROT), paste0("\"", related_BROT, "\"", "^^<xsd:string>"), NA),
+    PalmTraits_exact = ifelse(!is.na(PalmTraits_exact), paste0("\"", PalmTraits_exact, "\"", "^^<xsd:string>"), NA),
+    PalmTraits_close = ifelse(!is.na(PalmTraits_close), paste0("\"", PalmTraits_close, "\"", "^^<xsd:string>"), NA)
   ) %>%
   select(-identifier, -type_x, -traitID, -keyword_10) %>% 
   rename(
@@ -322,4 +323,39 @@ read_csv("data/APD_traits.csv") %>%
     Object = value
   ) %>% 
   filter(!is.na(Object)) %>%
-  mutate(Predicate = stringr::str_replace(Predicate, "\\>[:digit:]", "\\>")) %>% write_csv("data/reformatted_traits.csv") -> reformatted_traits
+  mutate(Predicate = stringr::str_replace(Predicate, "\\>[:digit:]", "\\>")) ->
+  triples_df
+
+
+# rdflib can't handle UTF-8 :(, see stringi::stri_enc_mark()
+triples_df %>% 
+  mutate(Object = stringi::stri_enc_toascii(Object),
+         graph = ".") %>% # quads have a fourth column, usually "."
+  filter(Object != "<NA>") %>% # we have some NAs sneaking in as URIs
+  write_delim("data/traits.nq", col_names=FALSE, escape="none", quote="none")
+
+# prove this parses correctly
+library(rdflib)
+true_triples <- read_nquads("data/traits.nq")
+
+# serialize to any format
+rdflib::rdf_serialize(true_triples, "data/traits.ttl")
+rdflib::rdf_serialize(true_triples, "data/traits.json", format="jsonld")
+
+# Smoke-tests / example sparql queries
+
+# how many unique predicates?
+sparql <-
+'SELECT DISTINCT ?p
+ WHERE { ?s ?p ?c . }
+'
+rdf_query(true_triples, sparql)
+
+# how many unique reviewers are in the data?
+sparql <-
+'SELECT DISTINCT ?orcid
+ WHERE { ?s <http://purl.org/datacite/v4.4/IsReviewedBy> ?orcid . }
+'
+rdf_query(true_triples, sparql)
+
+


### PR DESCRIPTION
Nice work @ehwenk , this looks great.  I tweaked the R code lightly for some minor RDF issues.

- angle-bracket for type-URIs (`<xsd:string>`)
- double-quote strings, single quotes elsewhere
- drop any `<NA>` URIs
- convert any UTF-8 to ACII (RDF is fine with UTF-8 but `rdflib` uses some old redland C bindings that aren't :( 
- escape `\` use.

Instead of writing to csv, we then write the three columns in the [n-quads](https://www.w3.org/TR/n-quads/)  serialization.  (ok, technically four columns, "quads" adds a "graph" column, which is simply ".", meaning all these triples are part of the same "graph").  

This looks nearly good.  One remaining thing is that n-quads, being a trivially simple format, doesn't support prefixes, so it looks like the `<xsd:string>` URIs will have to be expanded to use absolute URLs instead.  Not sure if there are any other prefixes. 

I added a few 'smoke test' SPARQL queries at the end.  SPARQL is kinda like SQL, but supports this cool trick where you can create that let you walk the graph.  You probably won't use it but it can be kinda cool, see examples at end of R file.  