### PR TITLE
docs: AusTraits family cross-linking, acknowledgements & citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 
 ![](inst/figures/logo.png)
 
-The AusTraits Plant Dictionary (APD) includes the trait definitions used by AusTraits, a database of Australian plant traits. Upon its release in 2023, the APD will include definitions for nearly 500 traits pertaining to plant functional ecology and plant morphology. Each trait definition has been reviewed by multiple people and includes references and links to identical/similar traits in other trait databases whenever possible. The APD includes machine-readable formats and endpoints, allowing the traits to be readily re-used by other databases.
+The AusTraits Plant Dictionary (APD) includes the trait definitions used by AusTraits, a database of Australian plant traits. The APD includes definitions for nearly 500 traits pertaining to plant functional ecology and plant morphology. Each trait definition has been reviewed by multiple people and includes references and links to identical/similar traits in other trait databases whenever possible. The APD includes machine-readable formats and endpoints, allowing the traits to be readily re-used by other databases.
+
+**Using the APD?** See the [Using the APD](https://traitecoevo.github.io/APD/using_the_APD.html) guide for how to access the trait definitions and machine-readable endpoints.
 
 The APD is described in the following citation:
 
-> Wenk EH, Sauquet H, Gallagher RV, Brownlee R, Boettiger C, Coleman D, Yang S, Auld T, Barrett RL, Brodribb T, Choat B, Dun L, Ellsworth D, Gosper C, Guja L, Jordan GJ, Breton T, Leigh A, Irving P, Medlyn B, Nolan R, Ooi M, Sommerville KD, Vesk P, White M, Wright IJ, Falster DS (2024) The AusTraits Plant Dictionary. *Scientific Data* (in press) (preprint: [10.1101/2023.06.16.545047](http://doi.org/10.1101/2023.06.16.545047)]).
+> Wenk EH, Sauquet H, Gallagher RV, Brownlee R, Boettiger C, Coleman D, Yang S, Auld T, Barrett RL, Brodribb T, Choat B, Dun L, Ellsworth D, Gosper C, Guja L, Jordan GJ, Breton T, Leigh A, Irving P, Medlyn B, Nolan R, Ooi M, Sommerville KD, Vesk P, White M, Wright IJ, Falster DS (2024) The AusTraits Plant Dictionary. *Scientific Data* 11:537. <https://doi.org/10.1038/s41597-024-03368-z>
 
 ## This repository
 
@@ -105,5 +107,22 @@ knowledge and governance hub — before filing.
 
 ## Acknowledgements
 
-We are grateful to S Cox, J Smillie, K Levett, M Barlow, and C Brady for useful conversations. The AusTraits project received investment (<https://doi.org/10.47486/TD044>, <https://doi.org/10.47486/DP720>) from the Australian Research Data Commons (ARDC). The ARDC is funded by the National Collaborative Research Infrastructure Strategy (NCRIS). 
+We are grateful to S Cox, J Smillie, K Levett, M Barlow, and C Brady for useful conversations.
+
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
+
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).
+
+This work received investment ([DP720](https://doi.org/10.47486/DP720)) from the ARDC. 
 


### PR DESCRIPTION
Part of the family-wide README usability pass (see `traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

- Paper citation updated from *in press*/preprint to the **published** Sci Data 11:537 (DOI 10.1038/s41597-024-03368-z)
- Added a **Using the APD** consumer pointer near the top (the README is otherwise build-oriented)
- Replaced the drifted acknowledgement with the canonical **partner + ARDC/NCRIS "enabled by"** block (+ DP720). The AusTraits family block was already on `develop`.

Note: APD is mid release-prep on a local `prepare-for-release` branch; this PR targets `develop`, so fold into the release as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)