### PR TITLE
Fix a broken URL in the worked example, and add the redirect matrix check

### DIFF
--- a/plans/build-workflow-overhaul.md
+++ b/plans/build-workflow-overhaul.md
@@ -597,6 +597,14 @@ RewriteRule ^traits/([A-Za-z][A-Za-z0-9_.-]*)/?$ https://traitecoevo.github.io/A
 The 819 categorical values fail today only because the existing rule matches `trait_` and nothing
 else; widening the pattern is the whole fix.
 
+**How w3id resolves a path that is not an entity.** Anything the rules do not recognise falls through
+to the dictionary page, which is the right behaviour — better than a 404 — and it is why
+`w3id.org/APD/APD_traits.csv` returns HTML. That URL is published nowhere and nothing calls it; the
+published w3id forms are the base URI (used with content negotiation, which works), `index.html`,
+`release/<version>/index.html` and the scheme URIs. So this is not a defect and stage 5 does not need
+to address it. **Files are fetched from `traitecoevo.github.io`**, which is what C12 names and what
+`austraits.build` and `using_the_APD.qmd` use.
+
 Content negotiation and the versioned `release/X.Y.Z/` rules are untouched. **This PR to
 `perma-id/w3id.org` goes last** — and "last" now has a concrete meaning: the rule points at the live
 site, so the rewritten `index.html` must be merged to `master` and served by Pages *before* the PR

--- a/scripts/check_redirects.sh
+++ b/scripts/check_redirects.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Content-negotiation and identifier-resolution matrix for w3id.org/APD.
+#
+# Run it before a deploy, keep the output, run it after, diff the two. Every line
+# must be identical except where a change was intended. This is the check stage 6
+# of plans/build-workflow-overhaul.md schedules as `redirects.yml`.
+#
+#   scripts/check_redirects.sh > before.txt
+#   ... deploy ...
+#   scripts/check_redirects.sh | diff before.txt -
+#
+# It talks to the live service, so it needs network and it tests what users
+# actually get -- not what the repo contains.
+set -uo pipefail
+
+APD_VERSION="${APD_VERSION:-2.1.0}"
+
+resolve() {  # url -> "<status> <final-path>"
+  local url="$1" accept="${2:-}" args=(-s -o /dev/null -L)
+  [[ -n "$accept" ]] && args+=(-H "Accept: $accept")
+  printf '%s %s' \
+    "$(curl "${args[@]}" -w '%{http_code}' "$url")" \
+    "$(curl "${args[@]}" -w '%{url_effective}' "$url" | sed 's|https://traitecoevo.github.io/APD/||')"
+}
+
+echo "# Content negotiation"
+for accept in text/turtle application/n-triples application/n-quads \
+              application/ld+json text/html; do
+  for path in "" /traits /glossary; do
+    printf '%-22s %-26s -> %s\n' "$accept" "APD${path}" \
+      "$(resolve "https://w3id.org/APD${path}" "$accept")"
+  done
+done
+
+echo
+echo "# Identifier resolution -- one per entity class"
+for path in traits/trait_0000012 traits/trait_group_0000008 \
+            traits/plant_growth_form_tree glossary/glossary_40004; do
+  printf '%-40s -> %s\n' "$path" "$(resolve "https://w3id.org/APD/$path")"
+done
+
+echo
+echo "# Versioned permalink -- published by index.qmd's \"This version\" link"
+printf '%-40s -> %s\n' "release/${APD_VERSION}/index.html" \
+  "$(resolve "https://w3id.org/APD/release/${APD_VERSION}/index.html")"
+
+# w3id resolves any path it does not recognise as an entity to the dictionary page,
+# which is the intended fallback. So the data files are fetched from github.io --
+# see COMMITMENTS.md C12 -- and it is those URLs that have to serve data rather
+# than HTML. A wrong one still returns 200, so check the body, not the status.
+echo
+echo "# Published data files -- must serve data, not the HTML page"
+SITE="https://traitecoevo.github.io/APD"
+for path in APD_traits.csv APD_categorical_values.csv APD.ttl APD.nt APD.nq \
+            APD.json "release/${APD_VERSION}/APD_traits.csv" \
+            "release/${APD_VERSION}/APD_categorical_values.csv"; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' -L "$SITE/$path")"
+  body="$(curl -s -L "$SITE/$path" | head -c 24)"
+  if [[ "$body" == *"<!DOCTYPE"* || "$body" == *"<html"* ]]; then
+    printf '%-46s %s HTML -- WRONG\n' "$path" "$code"
+  else
+    printf '%-46s %s data\n' "$path" "$code"
+  fi
+done

--- a/using_the_APD.qmd
+++ b/using_the_APD.qmd
@@ -20,9 +20,14 @@ library(tidyverse)
 library(stringr)
 library(kableExtra)
 
-# The published, version-pinned tables. Pin the version so your analysis is
-# reproducible; drop `release/2.1.0/` for the latest release instead.
-apd <- "https://w3id.org/APD/release/2.1.0"
+# The published tables. Pin the version so your analysis stays reproducible; drop
+# `release/2.1.0/` for whatever the current release is.
+#
+# These are github.io URLs. Cite the APD by its persistent identifier,
+# https://w3id.org/APD, and use that with an `Accept` header to fetch the RDF (see
+# below) -- but fetch the data files from here: w3id.org resolves anything it does
+# not recognise as an entity to the dictionary page.
+apd <- "https://traitecoevo.github.io/APD/release/2.1.0"
 
 APD_traits <- read_csv(file.path(apd, "APD_traits.csv"), show_col_types = FALSE)
 APD_categorical_values <- read_csv(file.path(apd, "APD_categorical_values.csv"), show_col_types = FALSE)


### PR DESCRIPTION
Small follow-up to #48. Three files: a one-line fix to a published example, the
script that caught it, and a retraction in the plan.

## The bug

`using_the_APD.qmd` told readers to fetch:

```r
apd <- "https://w3id.org/APD/release/2.1.0"
read_csv(file.path(apd, "APD_traits.csv"))
```

That URL returns `text/html`, so `read_csv()` on it fails or reads the dictionary
page as data. **I introduced this in #48** while moving the example off
`raw.githubusercontent.com`. It now uses `https://traitecoevo.github.io/APD/release/2.1.0/`,
verified `200 text/csv`.

## Not a bug: how w3id handles unrecognised paths

I first wrote this up as a defect in the w3id redirect config and added it to
stage 5's scope. **That was wrong and is retracted here.** w3id resolves any path
it does not recognise as an entity to the dictionary page, which is the right
fallback — better than a 404.

`w3id.org/APD/APD_traits.csv` is published nowhere and nothing calls it: checked,
and the only occurrences anywhere were the three files I had just written. The
published w3id forms are the base URI (used with content negotiation, which
works), `index.html`, `release/<version>/index.html` and the scheme URIs. Data
files are fetched from `traitecoevo.github.io`, which is what COMMITMENTS.md C12
names and what `austraits.build` reads.

## `scripts/check_redirects.sh`

The matrix that found it, committed rather than left in a scratch directory. It is
what stage 6 schedules as `redirects.yml`, and it is the before/after check the
plan asks for around a deploy:

```
scripts/check_redirects.sh > before.txt
# ... deploy ...
scripts/check_redirects.sh | diff before.txt -
```

It covers content negotiation across all five formats, identifier resolution for
each of the four entity classes, the versioned permalink, and — separately —
whether each published data file serves data or the HTML page. That last check
inspects the body, because a wrong URL still returns `200`.

Two things it established against the live site, worth having recorded before the
next deploy:

- `traits/plant_growth_form_tree` resolves to `index.html` with **no fragment**,
  confirming the 819-categorical-value bug (gap C1) against the live service
- all five content-negotiation formats and `release/2.1.0/index.html` resolve
  correctly today, so there is a clean baseline to diff against

One note on the check itself: my first version compared 8 bytes of the body
against `<!DOCTYPE`, which is 9 characters, so it reported HTML as CSV and nearly
let the bug through. It reads 24 now.