### PR TITLE
master becomes release-only; record what the stage 6 gate found

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,11 @@
 # every data PR, and no guarantee it came from the inputs beside it. The site is
 # built here instead, from the checkout, on every push to master.
 #
-# ONE-TIME SETUP. The first run of this workflow will fail while the repository
-# is still on the legacy source. Set Settings -> Pages -> Source to
-# "GitHub Actions" and re-run it. Until that switch, the committed docs/ keeps
-# serving the live site unchanged -- which is why plans/build-workflow-overhaul.md
-# keeps docs/ tracked until this workflow has deployed and verify has passed.
+# Settings -> Pages -> Source is "GitHub Actions" (set 2026-07-28). Do not put it
+# back to a branch. Both builders were armed at once on the push that first ran
+# this workflow, and one push produced two deployments -- the legacy one from the
+# committed docs/, then this one, which won only because it finishes later. Once
+# docs/ stops being tracked, a legacy build would publish an empty site.
 name: deploy
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,29 +75,38 @@ that outlives its problem silences a check.
 
 ## Branches and releases
 
-`develop` is the default branch. **The site is published from `master`** — nothing reaches
-<https://traitecoevo.github.io/APD/> until it is there.
-
-`deploy.yml` renders and deploys it. Until **Settings → Pages → Source** is switched to *GitHub
-Actions*, Pages still serves the committed `master:/docs` tree instead, and `deploy.yml` fails at its
-last step — which is why `docs/` is still tracked, and why deleting it waits on that switch plus a
-green `verify` job. Stage 6 of [`plans/build-workflow-overhaul.md`](plans/build-workflow-overhaul.md)
-has the sequence.
+`develop` is the default branch and where all work lands. **`master` is the published release** — its
+tip is always exactly the last released state, and it moves *only when a release is cut*.
 
 | Merge | How | Why |
 |---|---|---|
-| feature branch → `develop` | **squash** | One commit per PR. `master`'s history is linear and has been built this way — every commit on it is a squashed PR. |
-| `develop` → `master` | **fast-forward** | Keeps that linear history *and* keeps `master` an ancestor of `develop`. |
-
-**Do not squash `develop` into `master`.** It would create a commit on `master` that is not in
-`develop`, permanently diverging the two: `git log master..develop` would stop meaning "work not yet
-released", later merges would stop being fast-forwards, and a release tag on `master` would point at a
-commit no other branch contains — which matters for a repo whose value proposition is persistent,
-citable identifiers, and whose tags Zenodo archives.
+| feature branch → `develop` | **squash** | One commit per PR. |
+| `develop` → `master` | **fast-forward, at a release** | Keeps `master` an ancestor of `develop`, so ancestry still answers "which release shipped this change". |
 
     git checkout master && git merge --ff-only develop && git push
 
 If that refuses, the branches have diverged and the reason needs finding, not forcing.
+
+**`master` used to move on every PR, and that was Pages' fault, not the merge strategy's.** Pages
+served `master:/docs`, so a doc fix or a site tweak had to reach `master` to go live — which is why
+commits like #44 and #46 sit on a branch meant to be a release line. `deploy.yml` publishes via
+Actions now, so that constraint is gone and `master` can sit still between releases. Consequences
+worth knowing:
+
+- **The live site changes only at a release.** `https://w3id.org/APD/` serves the latest *release*,
+  not the latest commit — which is what it should mean for a citable vocabulary. If a fix needs to be
+  live, cut a patch release; 2.1.1 was exactly that.
+- **C13 starts meaning what it says.** `austraits.build` reads
+  `raw.githubusercontent.com/traitecoevo/APD/master/data/APD_trait_hierarchy.csv`. That used to
+  resolve to the Pages branch; now it resolves to the last release. It is the last surviving instance
+  of the bug C12 already fixed for every other artefact — see COMMITMENTS.md.
+
+**Do not squash `develop` into `master`** to get a one-line-per-release log. It would create a commit
+on `master` that is not in `develop`, permanently diverging the two: `git log master..develop` would
+stop meaning "work not yet released", later merges would stop being fast-forwards, and a release tag
+on `master` would point at a commit no other branch contains — which matters for a repo whose value
+proposition is persistent, citable identifiers, and whose tags Zenodo archives. Release history is
+`git tag` and the Releases page; that is where to read it, not `git log master`.
 
 **Version bumps.** `DESCRIPTION` is the single source (`R/version.R`); `index.qmd` and
 `scripts/release.R` read it. Bump it when the *published output* changes, not only when a trait does —

--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -39,7 +39,7 @@ Additional constraint, not from the paper but equally binding:
 | # | Commitment | Source |
 |---|---|---|
 | C12 | The generated artefacts remain fetchable at their published URLs — `https://traitecoevo.github.io/APD/<file>` for the latest release and `.../APD/release/<version>/<file>` for a pinned one — for `APD.ttl`, `APD.nq`, `APD.nt`, `APD.json`, `APD_traits.csv` and `APD_categorical_values.csv`. | `austraits.build/scripts/build_traits_yml_from_APD.R`; `using_the_APD.qmd`; the w3id content-negotiation rules. Checked weekly against the live service by `redirects.yml`, and after every deploy. |
-| C13 | `data/APD_trait_hierarchy.csv` remains fetchable from `raw.githubusercontent.com/traitecoevo/APD/master/data/`. | `austraits.build` reads it from there. It is an input table, not a build product, so it has no published copy yet; `make release` now snapshots one, and C12 can absorb it after the next release. |
+| C13 | `data/APD_trait_hierarchy.csv` remains fetchable from `raw.githubusercontent.com/traitecoevo/APD/master/data/`. | `austraits.build` reads it from there. It is an input table, not a build product, so it has no published copy yet; `make release` now snapshots one, and C12 can absorb it after the next release. **`master` is now release-only** (see AGENTS.md), so this URL resolves to the last release rather than to the Pages branch — which is what it always should have meant. |
 
 **C12 used to name repo paths, not URLs**, and that was the mistake. It read
 "`APD_traits.csv` … remain fetchable from `raw.githubusercontent.com/.../master/`", which pinned two

--- a/plans/build-workflow-overhaul.md
+++ b/plans/build-workflow-overhaul.md
@@ -11,11 +11,12 @@
 > **Stage 5 is ready to open and its gate has passed** — see that section for the exact rule and the
 > evidence. Stage 6 (CI) went first, since it is what makes the deploy repeatable.
 >
-> **Stage 6's first PR is done**: all four workflows exist, `make site` gates on every published anchor,
-> and `scripts/check_redirects.sh` asserts rather than prints. It also found and fixed a live 404 —
-> `release/2.1.1/index.html`, a tagged and deposited permalink. What is left of stage 6 is behind a
-> manual switch of the Pages source to *GitHub Actions* and a green `verify` job; `docs/` stays tracked
-> until then. See that section for the four-step sequence.
+> **Stage 6's first PR is merged and its gate has passed** (2026-07-28). All four workflows run, the
+> site deploys from `master` via Actions, and `verify` is clean against the live service. It found and
+> fixed a live 404 on `release/2.1.1/index.html` — a tagged, deposited permalink — and two dependencies
+> that had never been declared. `master` is now **release-only**: it moves at a release, not per PR,
+> which was only possible once Pages stopped being served from `master:/docs`. All that remains of
+> stage 6 is untracking `docs/`.
 >
 > **No release needed to deploy this.** The dictionary is unchanged — verified against `master`, not
 > asserted: 27,523 statements both sides, differing only in 31 `min`/`max` literals reformatted from
@@ -752,16 +753,52 @@ resolves to a fragment of `index.html`, so `make site` now fails if any of the 1
 without its anchor — the check the Verification section below describes, run every time rather than
 once before the w3id PR.
 
-**Still gated, in this order:**
+**The gate passed on 2026-07-28.** `master` was fast-forwarded, `deploy.yml` ran, and the `verify`
+job came back clean against the live service: every content-negotiated endpoint, all four entity
+classes, all five `release/<v>/index.html` permalinks and every published data file, with only gap C1
+outstanding. Pages source is now *GitHub Actions*.
 
-1. Merge, fast-forward `master`, let `deploy.yml` run. Its last step will fail: Pages is still on the
-   legacy `master:/docs` source, so there is nothing for `deploy-pages` to publish to.
-2. Switch **Settings → Pages → Source** to *GitHub Actions* and re-run the workflow. The live site is
-   unaffected until this happens, because `docs/` is still committed and still being served.
-3. Confirm the `verify` job is green — that is the gate: every content-negotiated endpoint, every
-   entity class, every `release/<v>/index.html`, and the published data files, checked live.
-4. Then the second PR: gitignore and delete `docs/`, and drop `release` from `_quarto.yml` resources
-   (`deploy.yml` already copies it, so that line is now redundant rather than load-bearing).
+Two things did not go as this plan predicted, and both are worth recording:
+
+- **The deploy did not fail on the legacy source.** The plan assumed `deploy-pages` would refuse until
+  the source was switched by hand. It did not — `actions/deploy-pages` created a Pages deployment and
+  it went live while `build_type` still read `legacy`. The setting governs the *automatic* legacy
+  builder, not whether a workflow may deploy.
+- **So both builders were armed at once, and one push produced two deployments.** The legacy builder
+  published the committed `docs/` at 03:27:50; this workflow published its fresh render at 03:36:45
+  and won, but only because it finishes nine minutes later. Confirmed by the served `sitemap.xml`
+  carrying a render timestamp the committed copy does not have. That race is why the source was
+  switched even though the deploy already worked: it is not what makes Actions deploy, it is what
+  stops the legacy builder — and after `docs/` is untracked, a legacy build would publish an empty
+  site.
+
+**What is left:** the second PR — gitignore and delete `docs/`, and drop `release` from `_quarto.yml`
+resources (`deploy.yml` copies it now, so that line is redundant rather than load-bearing).
+
+A useful side effect of the fast-forward, before any of the above: `release/2.1.1/` went from 404 to
+200. It reached the site through the *legacy* path, from the committed `docs/release/2.1.1/`, so that
+published permalink was repaired independently of the Actions switch.
+
+**Decided on review: `master` becomes release-only.** The plan's line about fixing "the branch
+topology" turned out to be about the wrong thing. `master` churned on every PR — doc-only changes like
+#44 and #46 are on it — and the reflex reading is that the merge strategy is at fault. It is not:
+Pages served `master:/docs`, so *anything* that had to go live had to reach `master`. The merge
+strategy was downstream of the deploy mechanism.
+
+Standing up the Actions deploy removes the constraint, so `master` now moves **only at a release**,
+still by fast-forward. What that buys, beyond a release line that is actually a release line:
+`https://w3id.org/APD/` starts meaning the latest *release* rather than the latest commit, which is
+what it should mean for a citable vocabulary; and C13 — `austraits.build` reading
+`raw.githubusercontent.com/.../master/data/APD_trait_hierarchy.csv`, the last surviving instance of
+the bug C12 already fixed — silently starts resolving to a release instead of to the Pages branch.
+
+Squashing `develop` into `master` for a one-line-per-release log was considered and rejected: it
+diverges the branches permanently, and ancestry is what makes "which release shipped this change"
+answerable. Release history is `git tag`. Recorded in `AGENTS.md`.
+
+One impurity worth naming: the fast-forward that carried this CI work onto `master` is not a release.
+It could not be avoided — `deploy.yml` only triggers on push to `master`, so it had to get there
+before it could ever run. A bootstrap, once.
 
 **Decided: `export/` stays tracked.** The plan left it open. `tests/testthat/test-golden.R` uses the
 committed artefacts as its fixtures — that was stage 3's deliberate choice, to avoid committing a


### PR DESCRIPTION
Follow-up to #53. No code changes beyond a comment in `deploy.yml` — this is the decision and the evidence, written down where the next person will read it.

## `master` is now release-only

It used to move on every PR, which is why doc-only changes like #44 and #46 sit on a branch meant to be a release line. The reflex reading is that the `develop` → `master` merge strategy is at fault. It isn't: **Pages served `master:/docs`, so anything that had to go live had to reach `master`.** The merge strategy was downstream of the deploy mechanism. Now that `deploy.yml` publishes via Actions, `master` moves only at a release — still by fast-forward.

Squashing `develop` into `master` for a one-line-per-release log was considered and rejected: it diverges the branches permanently, and ancestry is what makes *"which release shipped this change"* answerable — which matters for a repo whose tags Zenodo archives. Release history is `git tag` and the Releases page.

Side effect worth having: **C13 now means what it says.** `austraits.build` reads `raw.githubusercontent.com/traitecoevo/APD/master/data/APD_trait_hierarchy.csv`; that used to resolve to the Pages branch, and now resolves to the last release. It was the last surviving instance of the bug C12 already fixed for every other artefact.

## Two things the plan predicted wrongly

1. **The deploy did not fail on the legacy source.** The plan assumed `deploy-pages` would refuse until the source was switched by hand. It didn't — it created a Pages deployment and went live while `build_type` still read `legacy`. That setting governs the *automatic legacy builder*, not whether a workflow may deploy.

2. **So both builders were armed at once.** One push produced two deployments: the legacy builder published the committed `docs/` at 03:27:50, this workflow published its fresh render at 03:36:45 and won — but only because it finishes nine minutes later. Confirmed by the served `sitemap.xml` carrying a render timestamp the committed copy doesn't have.

Switching the Pages source is therefore **not what makes Actions deploy — it's what disarms the legacy builder**, and it has to happen before `docs/` is untracked or a legacy build would publish an empty site. Done on 2026-07-28; live matrix re-checked clean immediately after.

## Gate status

`verify` came back clean against the live service: all content-negotiated endpoints, all four entity classes, all five `release/<v>/index.html` permalinks, every published data file. Only gap C1 outstanding, which is stage 5's job.

`release/2.1.1/` went 404 → 200 as a side effect of the fast-forward, via the *legacy* path from the committed `docs/release/2.1.1/` — so that permalink was repaired independently of the Actions switch.

**Remaining in stage 6:** untrack `docs/`, drop `release` from `_quarto.yml` resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)