### PR TITLE
CONTRIBUTING.md and RELEASING.md (stage 7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ al. 2024, doi:10.1038/s41597-024-03368-z).
   output format, the licence, the set of published input tables, or where the site deploys. The APD is
   described in a published paper (Wenk et al. 2024), and that paper is a specification — several of its
   claims are promises this repo has to keep, and some are currently broken.
+- **Editing a trait?** [`CONTRIBUTING.md`](CONTRIBUTING.md) has the spreadsheet and YAML routes, and
+  what counts as a breaking change. **Cutting a release?** [`RELEASING.md`](RELEASING.md), whose last
+  three steps are outside this repo and are the ones that get missed.
 - **Source data:** `data/` holds the inputs that define the dictionary. **Trait definitions live in
   `APD_traits_input.yml`, which is the source of truth** — YAML was adopted in #43 because CSV diffs
   were unreviewable. `make export-csv` checks out a spreadsheet view at `data/edit/APD_traits_input.csv`

--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -12,7 +12,9 @@ build software against it on the strength of those statements.
 **Read this before** changing a URI scheme, renaming or removing an output file, changing the licence,
 altering the set of published input tables, or changing where the site is deployed.
 
-Related: `AGENTS.md` (repo orientation), and
+Related: [`CONTRIBUTING.md`](CONTRIBUTING.md) (editing a trait, and what makes a change breaking),
+[`RELEASING.md`](RELEASING.md) (the release checklist, including C8 and C9), `AGENTS.md`
+(repo orientation), and
 [`austraits-meta/governance/release-playbooks.md`](https://github.com/traitecoevo/austraits-meta/blob/main/governance/release-playbooks.md)
 for the downstream ripple when the vocabulary itself changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to the APD
+
+Thanks for helping improve the AusTraits Plant Dictionary.
+
+**Before anything else: the APD is a contract.** People cite it, software resolves its URIs, and
+Wenk et al. 2024 describes it in print. [`COMMITMENTS.md`](COMMITMENTS.md) lists what this repository
+has promised and what checks defend each promise — read it before changing a URI, an output format,
+the licence, or the set of published input tables.
+
+---
+
+## Just want to suggest a trait?
+
+You do not need to clone anything. Open a
+[new trait suggestion](https://github.com/traitecoevo/APD/issues/new?template=new-trait-suggestion.md)
+and describe what you need. That is the intended route for most people, and it is a published
+commitment in its own right (C11).
+
+Everything below is for editing the dictionary directly.
+
+---
+
+## One-time setup
+
+You need R (≥ 4.5), [Quarto](https://quarto.org/docs/get-started/), and `make`.
+
+```bash
+git clone https://github.com/traitecoevo/APD.git
+cd APD
+Rscript -e 'install.packages("pak"); pak::local_install_deps()'
+make            # lists every target
+```
+
+`pak::local_install_deps()` reads `DESCRIPTION`, which is the single declaration of what the build
+needs. If something is missing at run time, `make` says exactly what to install rather than failing
+somewhere inside the pipeline.
+
+## Editing trait definitions
+
+`data/APD_traits_input.yml` is the source of truth. There are two ways in, and neither is more
+correct than the other.
+
+### In a spreadsheet
+
+```bash
+make export-csv     # writes data/edit/APD_traits_input.csv -- 46 columns, same order as always
+                    # open it in Excel, scan and edit
+make import-csv     # writes the YAML back, and prints a per-trait diff to review
+make check
+git diff data/APD_traits_input.yml
+```
+
+`data/edit/` is gitignored. It is a **checkout**, not a second source of truth — the round trip is
+byte-lossless and there is a test that keeps it that way, but the CSV is scratch and the YAML is what
+gets committed.
+
+### Directly in the YAML
+
+For a one- or two-field fix this is usually faster: one block per trait, and the diff shows the field
+you changed rather than a 750-byte row.
+
+```bash
+$EDITOR data/APD_traits_input.yml
+make check
+```
+
+**Every scalar in that file is quoted text, including `min` and `max`.** That is deliberate — those
+values end up inside RDF literals, so text is the honest representation. Storing them as numbers made
+the published output depend on R's `options(scipen)`, which is how `1e+05` once shipped where
+`100000` was meant. Keep the quotes.
+
+## The other input tables
+
+Allowable categorical values, the trait hierarchy, glossary, units, references, reviewers, namespaces
+and annotation properties are CSVs in `data/`. Edit them directly. `data/APD_namespace_declaration.csv`
+is the **only** namespace map the build reads — do not add a second one in `R/`.
+
+## Before you open a PR
+
+```bash
+make check
+```
+
+That rebuilds the dictionary, parses all four RDF serialisations, runs `validate_apd()` and runs the
+test suite. It reports at two severities:
+
+- **`FAIL`** — a regression. Fix it.
+- **`gap`** — a problem that is already in the published dictionary, listed in `APD_KNOWN_GAPS`
+  (`R/validate.R`) with the reason it is still open. There are currently nine. They are expected;
+  they do not fail the build; and each needs its own reviewed change because every one of them alters
+  published output.
+
+Anything *not* on that register fails, so new breakage cannot hide behind the existing debt.
+
+Then open a pull request against **`develop`** (the default branch — not `master`). CI will build,
+validate and, if you touched anything that affects the site, render it and attach the page as an
+artefact so a reviewer can open the real thing.
+
+### Commit the rebuilt artefacts
+
+`export/` is generated but **tracked**, because `tests/testthat/test-golden.R` uses those files as its
+golden fixtures. So a data change is two commits:
+
+1. the input change, and
+2. the rebuilt `export/` that follows from it
+
+Keeping them apart is what makes the first one reviewable. `make check` tells you when they have
+drifted apart.
+
+`docs/` is **not** tracked — it is a local build artefact. Don't commit it.
+
+## What makes a change *breaking*
+
+The APD feeds `austraits.build`, which feeds the released AusTraits database. Per the family
+[release playbook](https://github.com/traitecoevo/austraits-meta/blob/main/governance/release-playbooks.md),
+**default to treating these as breaking**:
+
+- renaming or removing a trait, trait group, categorical value or glossary term
+- changing any **URI** — the one thing that must never change silently. A redirect *target* can move
+  freely; the identifier itself was published.
+- removing or renaming a column in `APD_traits.csv` or `APD_categorical_values.csv`
+- changing an allowed categorical value, a unit, or an allowed range
+
+A breaking change needs the `cross-package` and `breaking` labels, an issue linked across repos, and
+coordination with `austraits.build` — records using a removed trait or a disallowed value surface as
+validation failures there, not here.
+
+Adding a trait, or improving a description, comment, keyword or reference, is not breaking.
+
+## Where things live
+
+| | |
+|---|---|
+| `data/` | the inputs that define the dictionary — **edit these** |
+| `R/`, `scripts/`, `Makefile` | the build |
+| `export/` | generated artefacts; rebuilt by `make data`, tracked as test fixtures |
+| `docs/` | the rendered site; generated, gitignored |
+| `release/<version>/` | published snapshots; never edit a shipped one |
+| `index.qmd`, `using_the_APD.qmd`, `NEWS.md` | the website's source pages |
+
+Never hand-edit `export/`, `docs/` or `release/`. Edit `data/` and rebuild.
+
+## More
+
+- [`AGENTS.md`](AGENTS.md) — repo orientation, CI, branch and release conventions
+- [`COMMITMENTS.md`](COMMITMENTS.md) — what the APD guarantees, and the known gaps
+- [`RELEASING.md`](RELEASING.md) — for maintainers cutting a release
+- [`plans/`](plans/) — design documents, kept current including where they turned out to be wrong

--- a/README.md
+++ b/README.md
@@ -153,9 +153,16 @@ where, and which are currently unmet. Read it before changing a URI scheme, an
 output format, the licence, the set of published input tables, or where the site
 deploys.
 
-[`AGENTS.md`](AGENTS.md) is the working guide — architecture, gotchas, and the
-cross-package context. [`plans/`](plans/) holds design documents for work in
-progress.
+Then pick the guide that matches what you are doing:
+
+* **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — proposing or editing a trait, and what
+  makes a change *breaking*. Start here if you are not sure.
+* **[`RELEASING.md`](RELEASING.md)** — cutting a release, including the three steps
+  that live outside this repository and get missed.
+* [`AGENTS.md`](AGENTS.md) — the working guide: architecture, CI, branch and release
+  conventions, gotchas, cross-package context.
+* [`plans/`](plans/) — design documents for work in progress, kept current including
+  where they turned out to be wrong.
 
 ## Licensing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,144 @@
+# Releasing the APD
+
+For maintainers. A release is the only time the **published** dictionary changes: `master` is
+release-only, so nothing reaches <https://traitecoevo.github.io/APD/> until you do this.
+
+The steps that get forgotten are at the end, and they are the ones outside this repository —
+**ARDC RVA**, **Zenodo**, and the **downstream version pin**. As of 2026-07-28 two of the three are
+stale, which is the argument for the checklist.
+
+---
+
+## When to bump
+
+Bump `DESCRIPTION` when the **published output** changes, not only when a trait does. 2.1.1 was a
+patch release with no change to any definition, because the RDF began asserting typed numbers where it
+had asserted strings — that is a change to what consumers parse, so it needed a version.
+
+`DESCRIPTION` is the single source (`R/version.R`); `index.qmd` and `scripts/release.R` read it. Do
+not record the version anywhere else.
+
+Use [semver](https://semver.org/) as the family reads it: **major** for a breaking vocabulary change
+(a renamed or removed trait, a changed URI, a dropped column), **minor** for new traits or values,
+**patch** for corrections that do not invalidate anything built against the previous release.
+
+## 1. Prepare, on `develop`
+
+```bash
+git checkout develop && git pull
+```
+
+- Bump `Version:` in `DESCRIPTION`.
+- Add a `## APD Version <X.Y.Z>` section to `NEWS.md`. `make release` refuses without one, and the
+  section immediately below yours is what the site publishes as "Previous version".
+- Note anything breaking, and anything that closes a gap in `COMMITMENTS.md`.
+
+```bash
+make release
+```
+
+That runs `check`, then `site`, then `scripts/release.R`, which:
+
+- confirms the version has a change log entry
+- regenerates `APD_traits_input.csv` — untracked, but Wenk et al. 2024 documents it by name, so every
+  release has to carry it
+- snapshots nine files into `release/<version>/`
+
+It **refuses to overwrite an existing non-empty `release/<version>/`**. If it does, you forgot to bump
+`DESCRIPTION`. Overriding that with `APD_FORCE_RELEASE=1` rewrites a published snapshot — only do it
+if you know that is what you want.
+
+Commit the version bump, the change log, the rebuilt `export/`, and the new `release/<version>/`. Open
+a PR to `develop`, let CI pass, merge.
+
+## 2. Publish
+
+```bash
+git checkout master && git merge --ff-only develop && git push
+```
+
+If that refuses, the branches have diverged and the reason needs finding, not forcing.
+
+The push triggers [`deploy.yml`](.github/workflows/deploy.yml), which validates, renders, copies
+`release/` into the site, deploys to Pages, and then runs `scripts/check_redirects.sh` against the
+live service. **Wait for the `verify` job.** A green deploy and a resolving site are different claims;
+`verify` is the one that checks the second.
+
+```bash
+git tag v<X.Y.Z> && git push --tags
+gh release create v<X.Y.Z> --title "APD v<X.Y.Z>" --notes-file <notes> release/<X.Y.Z>/*
+```
+
+Attach the whole snapshot directory — nine files. Releases before 2.1.1 carried **no assets at all**,
+which meant Zenodo archived only a source tarball of the tag.
+
+## 3. The three things outside this repo
+
+This is the part that gets missed.
+
+### Zenodo — commitment C9
+
+Concept DOI [`10.5281/zenodo.8040789`](https://doi.org/10.5281/zenodo.8040789). The GitHub integration
+deposits on release; confirm the new version appears and carries the assets, not just the tarball.
+
+### ARDC Research Vocabularies Australia — commitment C8
+
+<https://vocabs.ardc.edu.au/viewById/649> must serve the new `APD.ttl`. Figure 4 of the paper promises
+a copy is "archived and discoverable" there.
+
+> **Currently stale: RVA serves 2.0.1 against a repo at 2.1.1.** Two releases behind. Nothing
+> automated catches this, which is why it is on the checklist rather than in CI.
+
+### The downstream pin
+
+`austraits.build/scripts/build_traits_yml_from_APD.R` has an `apd_version` constant that selects which
+pinned release it reads:
+
+```r
+apd_version <- "2.1.0"    # line 16
+```
+
+Bump it, re-run the script to regenerate `config/traits.yml`, and rebuild. Trait validation failures
+there are the point — they are records using something this release changed.
+
+> **Currently stale: it pins 2.1.0 against an APD at 2.1.1.**
+
+Sibling databases that pin the APD (`AusFizz`, `ausinvertraits.build`) need the same treatment. For a
+breaking change, follow the
+[family release playbook](https://github.com/traitecoevo/austraits-meta/blob/main/governance/release-playbooks.md)
+and label the issues `cross-package` + `breaking`.
+
+## 4. Re-check the commitments
+
+```bash
+make check                     # the automatable subset, plus the known-gaps register
+scripts/check_redirects.sh     # the live service (deploy.yml already ran this; run it again if you
+                               # changed anything after the deploy)
+```
+
+If a **known gap has started passing**, `check_redirects.sh` fails on purpose — a register entry that
+outlives its problem silences a check. Delete the entry from `COMMITMENTS.md` and from the script, and
+say so in `NEWS.md`.
+
+Then re-read [`COMMITMENTS.md`](COMMITMENTS.md) and update anything this release changed: the "Checked
+by" column, the known-gaps list, and C8's staleness note.
+
+---
+
+## Checklist
+
+```
+[ ] DESCRIPTION bumped
+[ ] NEWS.md section added
+[ ] make release            (refuses if either of the above is missing)
+[ ] PR to develop, CI green, merged
+[ ] master fast-forwarded and pushed
+[ ] deploy.yml verify job green
+[ ] tag pushed
+[ ] GitHub Release created with all nine assets
+[ ] Zenodo deposit confirmed                              (C9)
+[ ] ARDC RVA deposit refreshed                            (C8)
+[ ] austraits.build apd_version bumped and rebuilt
+[ ] sibling databases rebuilt, if the change is breaking
+[ ] COMMITMENTS.md re-read and updated
+```

--- a/plans/build-workflow-overhaul.md
+++ b/plans/build-workflow-overhaul.md
@@ -16,7 +16,11 @@
 > fixed a live 404 on `release/2.1.1/index.html` — a tagged, deposited permalink — and two dependencies
 > that had never been declared. `master` is now **release-only**: it moves at a release, not per PR,
 > which was only possible once Pages stopped being served from `master:/docs`. `docs/` is untracked.
-> **Stage 6 is complete**; only stage 7 (documentation) remains.
+>
+> **Stages 0–4, 6 and 7 are done.** `CONTRIBUTING.md` and `RELEASING.md` are written; writing the
+> release checklist found that the ARDC RVA deposit is two releases behind and that
+> `austraits.build` still pins APD 2.1.0. **Stage 5 — the one-line w3id rule change that fixes 819
+> published identifiers — is the only stage left**, and it is a PR to a third-party repository.
 >
 > **No release needed to deploy this.** The dictionary is unchanged — verified against `master`, not
 > asserted: 27,523 statements both sides, differing only in 31 `min`/`max` literals reformatted from
@@ -832,6 +836,30 @@ Two audiences, currently served by neither:
   serving 2.0.1 against a repo at 2.1.0) and **re-run the `COMMITMENTS.md` checks**.
 - **`COMMITMENTS.md`** (written in Stage 0) linked from both, and from `AGENTS.md`.
 - Correct `README.md` and `AGENTS.md` on the YAML-vs-CSV source of truth and the default branch.
+
+**Where stage 7 got to.** Both documents are written and cross-linked from `README.md`, `AGENTS.md`
+and `COMMITMENTS.md`. The source-of-truth and default-branch corrections had already been made in
+stages 3 and 6, so nothing was left to fix there.
+
+Writing the release checklist meant checking each of its steps against reality, and **two of the
+three cross-boundary ones are stale right now** — which is the whole argument for having the list:
+
+| Step | State on 2026-07-28 |
+|---|---|
+| ARDC RVA deposit (C8) | serving **2.0.1** against a repo at **2.1.1** — two releases behind, not one as this plan recorded |
+| `austraits.build` `apd_version` | pinned to **"2.1.0"** at `scripts/build_traits_yml_from_APD.R:16`, so downstream builds against the previous release |
+| Zenodo (C9) | current — 2.1.1 deposited with its nine assets |
+
+Neither stale item is detectable from inside this repository, so neither is a candidate for CI. They
+are checklist items in `RELEASING.md`, with the current staleness recorded inline so the next person
+cutting a release sees it rather than trusting the list is already satisfied.
+
+One thing the plan did not anticipate: **the family release playbook is itself stale for APD.**
+`austraits-meta/governance/release-playbooks.md` still says to edit the `*_input.csv` source files and
+rebuild via `build.qmd`. The CSV stopped being the source of truth in stage 3 and `build.qmd` was
+deleted in stage 2, so step 1 of the cross-package sequence is wrong in both particulars. It carries a
+"templates, not verified runbooks" warning, which is honest, but it needs a fix in that repository —
+out of scope here, and not something a reader of this repo would ever discover.
 
 ---
 


### PR DESCRIPTION
The last stage of [`plans/build-workflow-overhaul.md`](plans/build-workflow-overhaul.md) that lives in this repo. Two audiences the repo served with neither.

## `CONTRIBUTING.md` — the trait editor

Leads with the **issue template**, because most people shouldn't have to clone anything, and that route is commitment C11. Then, for people editing directly:

- both paths — spreadsheet (`make export-csv` → edit → `make import-csv`) and the YAML directly, with the honest note that for a one-field fix the YAML is usually faster
- why every scalar including `min`/`max` is quoted text (they end up in RDF literals; storing them as numbers is how `1e+05` once shipped where `100000` was meant)
- the two severities `make check` reports, and that the nine `gap` lines are expected
- why `export/` is committed in a **separate commit** from the input change — it's `test-golden.R`'s fixture set, and separating them is what keeps the input diff reviewable
- what counts as **breaking**, per the family release playbook

## `RELEASING.md` — the maintainer

The checklist. Writing it meant checking each step against reality, and **two of the three cross-boundary steps are stale right now** — which is the argument for a list rather than a memory:

| Step | State today |
|---|---|
| ARDC RVA deposit (C8) | serving **2.0.1** against a repo at **2.1.1** — two releases behind, not one as the plan recorded |
| `austraits.build` `apd_version` | pinned to **`"2.1.0"`** at `scripts/build_traits_yml_from_APD.R:16` |
| Zenodo (C9) | current — 2.1.1 deposited with its nine assets |

Neither stale item is detectable from inside this repository, so neither is a CI candidate. Both are recorded inline in the checklist with their current state, so the next person sees the gap rather than trusting the list is already satisfied.

## One thing found along the way, out of scope here

**The family release playbook is itself stale for APD.** `austraits-meta/governance/release-playbooks.md` step 1 still says to edit the `*_input.csv` source files and rebuild via `build.qmd`. The CSV stopped being the source of truth in stage 3, and `build.qmd` was deleted in stage 2 — so it's wrong in both particulars. It carries a "templates, not verified runbooks" warning, which is honest, but it needs a fix in that repo. Recorded in the plan; happy to open that PR separately.

Cross-linked from `README.md`, `AGENTS.md` and `COMMITMENTS.md`. All local links verified to resolve. `make check` green, same nine gaps.

**After this, stage 5 is the only thing left** — the one-line w3id rule change, still waiting on your go-ahead since it's a PR to `perma-id/w3id.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)