### PR TITLE
Simplify and document convert_to_triples.R and create_APD_trait_table.R (#49)

### DIFF
--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -100,17 +100,31 @@ outlives the problem it describes.
 
   | What | Scale | Where |
   |---|---|---|
-  | Dates and URIs are typed `^^<xsd:date>` / `^^<xsd:anyURI>` — a prefixed name where RDF requires an absolute URI, so it resolves as a *relative* reference rather than the XSD datatype. **Deliberately not fixed with the others:** the dates are `M/D/YYYY`, not ISO 8601, so correcting the datatype URI alone would move them from *unknown* datatype to *invalidly typed*. Needs the 1,363 dates reformatted, which is a data decision. [`rdf-datatype-relative-uri`] | 1,371 | `R/convert_to_triples.R:201,243-245` |
+  | Dates and URIs are typed `^^<xsd:date>` / `^^<xsd:anyURI>` — a prefixed name where RDF requires an absolute URI, so it resolves as a *relative* reference rather than the XSD datatype. **Deliberately not fixed with the others:** the dates are `DD/MM/YYYY`, not ISO 8601, so correcting the datatype URI alone would move them from *unknown* datatype to *invalidly typed*, so the 1,363 dates have to be reformatted in the same change. Day-first is unambiguous and consistent — 764 of the 1,353 values have a first component above 12 and none has a second above 12 — so this is a deterministic reformat, **not** the data decision this table used to call it. Tracked in [#59](https://github.com/traitecoevo/APD/issues/59). [`rdf-datatype-relative-uri`] | 1,371 | `R/convert_to_triples.R:225,269-271` |
   | `dcterms:license` and `dcterms:publisher` wrap their URI in angle brackets *inside* the string literal, so the published value is the string `"<https://…>"` rather than the URI. [`rdf-uri-inside-literal`] | 8 | `data/APD_resource.csv` |
 
-- **Input data — three unresolved references and two duplicated keys.** `TO_0000432` (4 traits) and
-  `ENVO:01001125` (1 trait) are used as keywords but are absent from `published_classes.csv`, so they
-  publish as `NA [id]`; `ENVO:01001125` also uses `:` where every ENVO entry in that file uses `_`.
-  `data/APD_units.csv` has `[ppm]` on two rows with different labels and URIs — the second is *parts
-  per thousand* and should be `[ppth]`, so the published RDF asserts the wrong identifier for that
-  unit. `published_classes.csv` has four duplicated identifiers, two on rows that disagree. Fixing
-  these needs the labels from the source ontologies and a decision on which duplicate row wins.
-  [`unresolved-identifier`, `input-duplicate-key`, `input-redundant-row`]
+- **Input data — two unresolved references, four duplicated keys, one free typo.** All tracked in
+  [#59](https://github.com/traitecoevo/APD/issues/59).
+
+  `TO_0000432` (4 traits) and `ENVO:01001125` (1 trait) are used as keywords but are absent from
+  `published_classes.csv`, so they publish as `NA [id]`. Fixing needs the labels from the source
+  ontologies, or a decision to drop the keyword. [`unresolved-identifier`]
+
+  `published_classes.csv` has four duplicated identifiers — `EnvThes:21211`, `TO_0000006`,
+  `TO_0001017`, `TO_0002616` — two repeated on identical rows and two on rows that disagree, which
+  needs a decision on which row wins. [`input-duplicate-key`, `input-redundant-row`]
+
+  `data/APD_units.csv` has `[ppm]` in the `identifier` cell of two rows. **This one is free, and this
+  table used to describe it wrongly.** The second row is parts per thousand and its URI, label and
+  UCUM code all say so; only that cell is a typo for `[ppth]`. No part of the build reads the column —
+  `convert_to_triples.R` matches units on `label` and `Entity` — so the published RDF is already
+  correct for both units and for the 3 traits pointing at the ppm URI and 14 at ppth. Fixing it
+  changes no output and needs no decision. [`input-duplicate-key`]
+
+  > This table previously said `ENVO:01001125` "uses `:` where every ENVO entry in that file uses
+  > `_`", and that the units row made "the published RDF assert the wrong identifier". Neither is
+  > true: there are no ENVO entries in `published_classes.csv`, which already carries 95 colon-style
+  > identifiers against 657 underscore-style; and the units `identifier` column reaches no output.
 
 - **C8 — stale.** ARDC RVA (`vocabs.ardc.edu.au/viewById/649`) serves **2.0.1**; this repo is at 2.1.0.
   Refreshing the deposit belongs on the release checklist.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,23 @@ format:
     toc-expand: 1
     embed-resources: true
 ---
+## Unreleased
+
+<!-- Rename this heading to `## APD Version <X.Y.Z>` when the next release is cut;
+     `apd_released_versions()` matches only that form, so an "Unreleased" section
+     is invisible to the version checks and to "Previous version" on the site. -->
+
+**Allowable categorical values now sit under their trait in the contents.** In
+section 4 of the dictionary, each of the 819 allowable values was headed at the
+same level as the 115 traits that own them, so the contents listed all 934 as one
+flat run — a value was indistinguishable from a trait, and a trait could not be
+collapsed. Values are now one level deeper, and the contents opens showing traits
+only.
+
+No definition, URI, label or allowable value changed, and the machine-readable
+serialisations are byte-for-byte identical. This is how the page is arranged, not
+what it says.
+
 ## APD Version 2.1.1
 
 A patch release. **The trait definitions are unchanged** — no trait, URI, label,

--- a/R/convert_to_triples.R
+++ b/R/convert_to_triples.R
@@ -3,6 +3,56 @@
 # drift, and so the "^^" is impossible to lose again.
 XSD_DOUBLE <- "^^<http://www.w3.org/2001/XMLSchema#double>"
 
+#' Mint the `skos:narrower` statements implied by a set of `skos:broader` ones
+#'
+#' The two are inverse properties, and the inputs only ever record the upward
+#' direction -- a trait names its group, a categorical value names its trait.
+#' SKOS consumers expect to be able to walk down as well, so each `broader`
+#' statement is asserted a second time with subject and object exchanged. Applied
+#' to the hierarchy, the trait table and the categorical values.
+#'
+#' @param triples A triple table already filtered to `skos:broader` statements.
+#' @return The same statements, inverted, as `skos:narrower`.
+as_narrower <- function(triples) {
+  triples %>%
+    mutate(Predicate = "<http://www.w3.org/2004/02/skos/core#narrower>") %>%
+    rename(Subject = Object, Object = Subject)
+}
+
+#' Turn the input tables into the RDF statements the APD publishes
+#'
+#' The one place the dictionary becomes RDF. Each input table is reshaped the
+#' same way -- decorate every cell so it is a legal N-Triples term (`<URI>`,
+#' `"literal"`, `"literal"@en`, `"literal"^^<datatype>`), rename each column to
+#' the predicate it stands for, then pivot to one row per statement -- and the
+#' results are stacked into a single subject/predicate/object table.
+#'
+#' Two products come back rather than one. `triples_df` is the graph as it will
+#' be serialised, with every term still in its RDF form. `triples_with_labels` is
+#' the same statements re-decorated for people: brackets stripped, and each URI
+#' resolved to the human label it stands for, so the website can print "leaf
+#' area" where the graph says a URI. The website and `APD_triples.csv` read only
+#' the latter.
+#'
+#' @param annotation_properties_csv The annotation properties -- the predicate
+#'   vocabulary, and the source of the human label each predicate is shown under.
+#' @param traits_csv The trait definitions, from `APD_traits_input.yml`. The bulk
+#'   of the graph; its list-valued fields are split and numbered so each element
+#'   becomes its own statement.
+#' @param glossary_csv Terms the APD defines itself, because no published
+#'   vocabulary defines them.
+#' @param published_classes_csv Terms borrowed from other vocabularies. Doubles
+#'   as the lookup that resolves a trait's type, structure, characteristic,
+#'   keywords and mappings to labels and URIs.
+#' @param reviewers_csv People who reviewed a trait definition, with ORCIDs.
+#' @param references_csv Literature cited by a trait definition.
+#' @param units_csv Units of measurement, with their SI and UCUM codes.
+#' @param hierarchy_csv The trait groups, and the parent of each.
+#' @param categorical_values_csv Allowable values for the categorical traits,
+#'   each attached to the single trait that permits it.
+#' @param APD_resource_csv Statements describing the dictionary itself --
+#'   licence, publisher, version -- passed through into the graph as written.
+#' @return A list of two tibbles, `triples_df` and `triples_with_labels`.
 convert_to_triples <- function(annotation_properties_csv, traits_csv, glossary_csv, published_classes_csv, reviewers_csv, references_csv, units_csv, hierarchy_csv, categorical_values_csv, APD_resource_csv) {
   
 reformatted_references <- 
@@ -22,11 +72,7 @@ reformatted_references <-
     `<http://purl.org/dc/terms/bibliographicCitation>` = citation,
     `<http://purl.org/dc/terms/title>` = title
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  )
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object")
 
 reformatted_reviewers <- 
   reviewers_csv %>%
@@ -41,11 +87,7 @@ reformatted_reviewers <-
     `<http://www.w3.org/2004/02/skos/core#prefLabel>`= label,
     `<http://purl.obolibrary.org/obo/IAO_0000708>` = ORCID
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  )
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object")
 
 reformatted_units <- 
   units_csv %>%
@@ -65,11 +107,7 @@ reformatted_units <-
     `<https://w3id.org/uom/SI_code>` = SI_code,
     `<https://w3id.org/uom/UCUM_code>` = UCUM_code
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  ) %>%
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object") %>%
   filter(!is.na(Object))
 
 reformatted_categorical <- 
@@ -95,11 +133,7 @@ reformatted_categorical <-
     `<http://purl.org/dc/terms/description>` = description,
     `<http://www.w3.org/2004/02/skos/core#broader>` = Parent
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  )
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object")
   
 reformatted_hierarchy <- 
   hierarchy_csv %>%
@@ -124,19 +158,13 @@ reformatted_hierarchy <-
       `<http://www.w3.org/2004/02/skos/core#broader>` = Parent,
       `<http://www.w3.org/2004/02/skos/core#exactMatch>` = exactMatch
     ) %>%
-    pivot_longer(cols = -Subject) %>% 
-    rename(
-      Predicate = name,
-      Object = value
-    ) %>% 
+    pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object") %>% 
   filter(!is.na(Object))
 
 reformatted_hierarchy_x <- 
   reformatted_hierarchy %>%
   filter(Predicate == "<http://www.w3.org/2004/02/skos/core#broader>") %>%
-  mutate(Predicate = "<http://www.w3.org/2004/02/skos/core#narrower>") %>%
-  rename(Object2 = Subject, Subject = Object) %>%
-  rename(Object = Object2)
+  as_narrower()
 
 reformatted_hierarchy <- 
   reformatted_hierarchy %>%
@@ -162,11 +190,7 @@ reformatted_glossary <-
     `<http://www.w3.org/2004/02/skos/core#prefLabel>` = label,
     `<http://purl.org/dc/terms/description>` = description
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  ) %>% 
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object") %>% 
   filter(!is.na(Object))
 
 reformatted_published_classes <- 
@@ -187,11 +211,7 @@ reformatted_published_classes <-
     `<http://purl.org/dc/terms/identifier>` = identifier,
     `<http://www.w3.org/2004/02/skos/core#inScheme>` = inScheme
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  ) %>% 
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object") %>% 
   filter(!is.na(Object))
  
 reformatted_annotation <- 
@@ -212,11 +232,7 @@ reformatted_annotation <-
     `<http://purl.org/dc/terms/created>`= issued,
     `<http://www.w3.org/2004/02/skos/core#note>`= comment
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  ) %>% 
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object") %>% 
   filter(!is.na(Object)) %>%
   filter(!stringr::str_detect(Object,"\"NA\"@en"))
 
@@ -281,8 +297,11 @@ reformatted_traits <- reformatted_traits %>%
   rename_with(~ paste0("<http://www.w3.org/2004/02/skos/core#exactMatch>", str_extract(., "[:digit:]+")), .cols = dplyr::contains("exact_match")) %>%
   rename_with(~ paste0("<http://www.w3.org/2004/02/skos/core#closeMatch>", str_extract(., "[:digit:]+")), .cols = dplyr::contains("close_match")) %>%
   rename_with(~ paste0("<http://www.w3.org/2004/02/skos/core#relatedMatch>", str_extract(., "[:digit:]+")), .cols = dplyr::contains("related_match")) %>%  
+  # Numbered from the selected columns themselves. This used to count them by
+  # re-selecting from `reformatted_traits`, i.e. the value the pipe started from,
+  # and only gave the right answer because the two selections happened to agree.
   rename_with(
-    ~ paste0("<http://www.w3.org/2004/02/skos/core#example>", seq_along(1:length(reformatted_traits %>% select(dplyr::contains("_exact") | dplyr::contains("_close") | dplyr::contains("_related"))))), 
+    ~ paste0("<http://www.w3.org/2004/02/skos/core#example>", seq_along(.)),
     .cols = dplyr::contains("_exact") | dplyr::contains("_close") | dplyr::contains("_related")) %>%
   rename(
     Subject = Entity,
@@ -304,28 +323,20 @@ reformatted_traits <- reformatted_traits %>%
     `<http://www.w3.org/2004/02/skos/core#changeNote>`= deprecated_trait_name,
     `<http://www.w3.org/2004/02/skos/core#scopeNote>`= constraints
   ) %>%
-  pivot_longer(cols = -Subject) %>% 
-  rename(
-    Predicate = name,
-    Object = value
-  )
+  pivot_longer(cols = -Subject, names_to = "Predicate", values_to = "Object")
 
 reformatted_traits_x <- 
   reformatted_traits %>%
   filter(stringr::str_detect(Predicate, "broader")) %>% 
   filter(!is.na(Object)) %>% 
   distinct(Subject, Object, .keep_all = TRUE) %>%
-  mutate(Predicate = "<http://www.w3.org/2004/02/skos/core#narrower>") %>%
-  rename(Object2 = Subject, Subject = Object) %>%
-  rename(Object = Object2) %>%
+  as_narrower() %>%
   filter(!is.na(Subject))
 
 reformatted_categorical_x <- 
   reformatted_categorical %>%
   filter(Predicate == "<http://www.w3.org/2004/02/skos/core#broader>") %>%
-  mutate(Predicate = "<http://www.w3.org/2004/02/skos/core#narrower>") %>%
-  rename(Object2 = Subject, Subject = Object) %>%
-  rename(Object = Object2)
+  as_narrower()
 
 reformatted_glossary_x <- reformatted_glossary %>%
   filter(Predicate == "<http://www.w3.org/2004/02/skos/core#topConceptOf>") %>%

--- a/R/create_APD_trait_table.R
+++ b/R/create_APD_trait_table.R
@@ -1,532 +1,357 @@
+# The property/value pairs shown under each entity on the rendered dictionary.
+#
+# `index.qmd` walks the four kinds of published entity -- trait groups, trait
+# concepts, allowable categorical values and glossary terms -- and calls one
+# builder per kind. Each returns a two-column tibble of `name` and `description`
+# list-columns, which `R/table.R` renders as a `<dl>`.
+#
+# Each builder is now a list of `prop()` calls, one per property, in the order
+# they appear on the page. They used to be 22 six-line blocks differing only in
+# which property they selected and how the value was formatted, which made the
+# shape of an entity's entry impossible to see at a glance.
+#
+# A builder emits a pair per property the entity *could* have, whether or not it
+# has one; `apd_definition_list()` drops the empties. That is why there are far
+# more pairs here than appear on the page.
 
+# Predicate namespaces. Kept as constants rather than inlined at each call site
+# both because the repetition was the bulk of the old file, and because
+# test-namespaces.R fails any file in R/ that accumulates more than a handful of
+# `name = "http..."` assignments -- the shape a second namespace map would take.
+SKOS <- "http://www.w3.org/2004/02/skos/core#"
+DCTERMS <- "http://purl.org/dc/terms/"
+DATACITE <- "http://purl.org/datacite/v4.4/"
+IADOPT <- "https://w3id.org/iadopt/ont/"
 
-add_row <- function(data, name, description) {
-  if(!("html" %in% class(name)))
-    name <- gt::html(name)
-  if (!("html" %in% class(description))) {
-    description <- gt::html(description)
+#' The triples describing one entity, with display links resolved
+#'
+#' All four builders open the same way: take the rows of the labelled triple
+#' table that describe one entity, then render each row's predicate and object as
+#' a link.
+#'
+#' Two builders match on `Subject` and two on `Subject_stripped`. The two columns
+#' are identical for every row of `APD_triples.csv` and a test in
+#' `test-entity-tables.R` pins that, so `key` records which one each builder
+#' meant rather than quietly collapsing them.
+#'
+#' @param triples_with_labels The labelled triple table, i.e. `APD_triples.csv`.
+#' @param subject URI of the entity to describe.
+#' @param key Name of the column to match `subject` against.
+#' @return The matching rows plus two character columns: `property_link`, the
+#'   predicate linked to its definition, and `value_link`, the object linked to
+#'   its target -- or left as plain text where the object is a literal rather
+#'   than a URI.
+apd_entity_rows <- function(triples_with_labels, subject, key = "Subject") {
+
+  triples_with_labels %>%
+    filter(.data[[key]] == subject) %>%
+    mutate(
+      property_link = purrr::map2_chr(
+        property, Predicate,
+        \(text, uri) as.character(make_link(text, uri))
+      ),
+      value_link = purrr::map2_chr(
+        value, Object,
+        \(text, uri) {
+          if (is.na(uri)) as.character(text) else as.character(make_link(text, uri))
+        }
+      )
+    )
+}
+
+#' One property/value pair of an entity's table
+#'
+#' The defaults describe the common case: select the entity's rows for one
+#' property, head the pair with that predicate's own label linked to its
+#' definition, and show the linked value. Every other argument exists because
+#' some property on some entity departs from that, and naming the departure at
+#' the call site is the point -- reading a builder should show what is unusual
+#' about each pair and nothing else.
+#'
+#' @param rows The entity's rows, from `apd_entity_rows()`.
+#' @param property Value of the `property` column to select.
+#' @param label,uri Head the pair with this fixed link instead of the predicate's
+#'   own label, for the predicates `APD_annotation_properties.csv` carries no
+#'   label for.
+#' @param collapse Stack the values into a single cell, one per line. This is
+#'   what distinguishes a list-valued property from a single-valued one.
+#' @param heading `"first"` gives the whole list one heading, `"each"` one
+#'   heading per value. Follows `collapse` unless overridden.
+#' @param column Which column supplies the value. `min`/`max` publish the raw
+#'   `value` rather than the linked form.
+#' @param values Supply the values directly, already aligned to the selected
+#'   rows, where a value needs more than a link.
+#' @param default Shown when the entity has no such property. Only two properties
+#'   say anything in that case; the rest render as an empty pair that
+#'   `apd_definition_list()` drops.
+#' @param skip_if_empty Emit no pair at all when there is nothing to show, rather
+#'   than an empty one.
+#' @param repeat_heading Repeat a fixed heading once per selected row -- and so
+#'   omit it entirely when there are no rows. Only `has context object` does
+#'   this, and it is published output.
+#' @return A `list(name, description)`, or `NULL` when the pair is skipped.
+prop <- function(rows, property, label = NULL, uri = NULL, collapse = FALSE,
+                 heading = if (collapse) "first" else "each",
+                 column = "value_link", values = NULL, default = NULL,
+                 skip_if_empty = FALSE, repeat_heading = FALSE) {
+
+  # Base subsetting rather than filter(): `property` names both an argument here
+  # and a column there, and filter() would resolve it to the column.
+  selected <- rows[!is.na(rows$property) & rows$property == property, ,
+                   drop = FALSE]
+
+  if (skip_if_empty && nrow(selected) == 0) {
+    return(NULL)
   }
 
-  bind_rows(
-    data, 
-    tibble(name = list(name), description = list(description))
+  if (is.null(values)) {
+    values <- selected[[column]]
+  }
+  if (nrow(selected) == 0 && !is.null(default)) {
+    values <- default
+  }
+
+  name <-
+    if (!is.null(label)) {
+      link <- make_link(label, uri)
+      # A fixed heading stands whether or not the entity has the property -- that
+      # is what makes `date reviewed` show up empty rather than vanish.
+      if (repeat_heading) rep(link, nrow(selected)) else link
+    } else if (identical(heading, "first")) {
+      selected$property_link[1]
+    } else {
+      selected$property_link
+    }
+
+  list(name = name,
+       description = if (collapse) html_lines(values) else values)
+}
+
+#' A pair whose heading is literal text rather than a predicate
+#'
+#' Only the `URI` row, which names the entity itself rather than a statement
+#' about it.
+#'
+#' @param name Heading text.
+#' @param description Value.
+#' @return A `list(name, description)`.
+literal_prop <- function(name, description) {
+  list(name = name, description = description)
+}
+
+#' Assemble property pairs into the table the renderer expects
+#'
+#' Both columns are list-columns because a value may be a `gt::html()` object, a
+#' plain string, or a vector of several, and a list-column holds all three
+#' without flattening. Built in one call rather than appended a pair at a time,
+#' which recopied the accumulating tibble about 25 times per entity and was half
+#' the cost of the entity-table build.
+#'
+#' @param pairs A list of `prop()` results; `NULL` entries are dropped.
+#' @return A tibble of `name` and `description` list-columns.
+property_table <- function(pairs) {
+
+  pairs <- Filter(Negate(is.null), pairs)
+
+  as_html <- function(x) if ("html" %in% class(x)) x else gt::html(x)
+
+  tibble(
+    name = lapply(pairs, function(pair) as_html(pair$name)),
+    description = lapply(pairs, function(pair) as_html(pair$description))
   )
 }
 
+#' Each allowable value of a categorical trait, with its definition
+#'
+#' A categorical trait lists its allowed values, and the page shows each one's
+#' definition beside it rather than making the reader jump to section 4. The
+#' definitions are statements about the *values*, so they come from the full
+#' triple table rather than from the trait's own rows.
+#'
+#' @param narrower The trait's `has narrower` rows.
+#' @param triples_with_labels The labelled triple table.
+#' @return A character vector, one entry per allowable value.
+categorical_value_lines <- function(narrower, triples_with_labels) {
+
+  definitions <- triples_with_labels %>%
+    filter(Subject_stripped %in% narrower$Object) %>%
+    filter(property %in% c("identifier", "description")) %>%
+    select(Subject_stripped, property, value) %>%
+    pivot_wider(names_from = property, values_from = value)
+
+  paste(narrower$value_link,
+        definitions$description[match(narrower$value, definitions$identifier)])
+}
+
+# Four traits record a season rather than a set of allowable values, so their
+# `has narrower` statements are not categorical values and are not listed.
+APD_TIME_TRAITS <- c("flowering_time", "fruiting_time", "recruitment_time",
+                     "foliage_time")
+
+#' Build the table for one trait concept
+#'
+#' The largest of the four: a trait carries the full annotation set -- labels,
+#' description, units and allowed range or allowed values, groupings, keywords,
+#' mappings out to other vocabularies, references, reviewers and dates. Produces
+#' section 3 of the dictionary, "Trait concepts".
+#'
+#' Which pairs appear depends on the trait's value type: continuous traits get
+#' units and a min/max, categorical traits get their allowable values inlined
+#' with each value's definition.
+#'
+#' @param thistrait URI of the trait, e.g.
+#'   `https://w3id.org/APD/traits/trait_0000012`.
+#' @param triples_with_labels The labelled triple table.
+#' @return A tibble of `name` and `description` list-columns.
 create_APD_trait_table <- function(thistrait, triples_with_labels) {
 
-  trait_i <- 
-    triples_with_labels %>% 
-    filter(Subject == thistrait) %>%
-    mutate(property_link = NA, value_link = NA)
-  
-  
-  for (i in seq_len(nrow(trait_i))) {
-    trait_i$property_link[i] <- make_link(trait_i$property[i], trait_i$Predicate[i])
-    trait_i$value_link[i] = ifelse(!is.na(trait_i$Object[i]), make_link(trait_i$value[i], trait_i$Object[i]), trait_i$value[i])
-  }
-  
-  output <- tibble(name =  list(), description = list())
+  trait <- apd_entity_rows(triples_with_labels, thistrait)
 
-  output <- 
-    add_row(output, "URI", trait_i$Subject[1])
-  
-  # label
-    label <- trait_i %>% filter(property == "preferred label")
-    
-    output <-
-      add_row(output,
-              label$property_link,
-              label$value_link
-              )
-  
-  # alternative label
-    altlabel <- trait_i %>% filter(property == "alternative label")
-    
-    output <-
-      add_row(output,
-              altlabel$property_link,
-              altlabel$value_link
-              )
-  
-  # description
-    description <- trait_i %>% filter(property == "description")
+  value_type <- trait %>% filter(property == "value type")
+  altlabel <- trait %>% filter(property == "alternative label")
+  narrower <- trait %>% filter(property == "has narrower")
 
-    output <-
-      add_row(output,
-              description$property_link[1],
-              print_list2(description$value_link)
-              )
+  property_table(c(
+    list(
+      literal_prop("URI", trait$Subject[1]),
+      prop(trait, "preferred label"),
+      prop(trait, "alternative label"),
+      prop(trait, "description", collapse = TRUE),
+      prop(trait, "note", label = "comments", uri = paste0(SKOS, "note")),
+      prop(trait, "value type")
+    ),
 
-  # comments
-    comments_tmp <- trait_i %>% filter(property == "note")
+    if (value_type$value == "continuous variable") list(
+      prop(trait, "unit", collapse = TRUE),
+      # The allowed range comes from `value`, not `value_link`: these are
+      # numbers, with nothing to link them to.
+      prop(trait, "minAllowedValue", column = "value"),
+      prop(trait, "maxAllowedValue", column = "value")
+    ),
 
-    output <-
-      add_row(output,
-              make_link("comments","http://www.w3.org/2004/02/skos/core#note"),
-              comments_tmp$value_link
-              )
+    if (value_type$value == "categorical variable" &&
+          !altlabel$value %in% APD_TIME_TRAITS) list(
+      prop(trait, "has narrower", collapse = TRUE,
+           values = categorical_value_lines(narrower, triples_with_labels))
+    ),
 
-   # value type
-     value_type <- trait_i %>% filter(property == "value type")
-
-     output <-
-      add_row(output,
-              value_type$property_link,
-              value_type$value_link
-              )
-
-  if(value_type$value == "continuous variable") {
-    units_tmp <- trait_i %>% filter(property == "unit")
-    min_tmp <- trait_i %>% filter(property == "minAllowedValue")
-    max_tmp <- trait_i %>% filter(property == "maxAllowedValue")
-    uom_tmp <- trait_i %>% filter(property == "units_uom")
-
-    output <-
-      add_row(output,
-              units_tmp$property_link[1],
-              print_list2(units_tmp$value_link)
-              )
-
-  # min & max
-    output <-
-      add_row(output,
-              min_tmp$property_link,
-              min_tmp$value
-              )
-
-    output <-
-      add_row(output,
-              max_tmp$property_link,
-              max_tmp$value
-              )
-
-   }
-
-  # categorical values (has narrower)
-    if(value_type$value == "categorical variable" & !altlabel$value %in% c("flowering_time", "fruiting_time", "recruitment_time", "foliage_time")) {
-
-      categorical_narrower <- trait_i %>%
-        filter(property == "has narrower")
-
-      categorical_defs <- triples_with_labels %>%
-        filter(Subject_stripped %in% categorical_narrower$Object) %>%
-        filter(property %in% c("identifier", "description")) %>%
-        select(Subject_stripped, property, value) %>%
-        pivot_wider(names_from = property, values_from = value)
-
-
-      categorical_narrower <- categorical_narrower %>%
-        mutate(
-          description = categorical_defs$description[match(categorical_narrower$value, categorical_defs$identifier)],
-          description2 = paste(value_link, description)
-          )
-
-      output <-
-        add_row(output,
-                categorical_narrower$property_link[1],
-                print_list2(categorical_narrower$description2)
-                )
-    }
-
-  # trait grouping (has broader)
-    grouping <- trait_i %>% filter(property == "has broader")
-
-    output <-
-      add_row(output,
-              grouping$property_link[1],
-              print_list2(grouping$value_link)
-              )
-
-  # measured entity (plant structure)
-    plant_structure <- trait_i %>% filter(property == "has context object")
-
-    plant_structure$property_link <- "<a href=\"https://w3id.org/iadopt/ont/hasContextObject\">plant structure</a>"
-    
-    output <-
-      add_row(output,
-              plant_structure$property_link,
-              print_list2(plant_structure$value_link)
-              )
-
-  # measured characteristic
-    characteristic <- trait_i %>% filter(property == "measured characteristic")
-
-    output <-
-      add_row(output,
-              characteristic$property_link[1],
-              print_list2(characteristic$value_link)
-              )
-
-  # keywords
-    keywords_tmp <- trait_i %>% filter(property == "keyword")
-
-    plant_structure$value_link <- print_list2(plant_structure$value_link)
-    
-    if (nrow(keywords_tmp) > 0) {
-      output <-
-        add_row(output,
-                keywords_tmp$property_link[1],
-                print_list2(keywords_tmp$value_link)
-                )
-    }
-
-  # scope
-    scope_tmp <- trait_i %>% filter(property == "scope note")
-
-    output <-
-      add_row(output,
-              make_link("scope note", "http://www.w3.org/2004/02/skos/core#scopeNote"),
-              scope_tmp$value_link
-              )
-
-  # exact match
-    exact_match <- trait_i %>% filter(property == "has exact match")
-
-    output <-
-      add_row(output,
-              make_link("has exact match", "http://www.w3.org/2004/02/skos/core#exactMatch"),
-              print_list2(exact_match$value_link)
-              )
-
-  # close match
-  close_match <- trait_i %>% filter(property == "has close match")
-
-  output <-
-    add_row(output,
-            make_link("has close match", "http://www.w3.org/2004/02/skos/core#closeMatch"),
-            print_list2(close_match$value_link)
-            )
-
-  # related match
-  related_match <- trait_i %>% filter(property == "has related match")
-
-  output <-
-    add_row(output,
-            make_link("has related match", "http://www.w3.org/2004/02/skos/core#relatedMatch"),
-            print_list2(related_match$value_link)
-            )
-
-  # examples (matches that are literals/strings)
-  examples <- trait_i %>% filter(property == "example")
-
-  output <-
-    add_row(output,
-            make_link("examples", "http://www.w3.org/2004/02/skos/core#example"),
-            print_list2(examples$value_link)
+    list(
+      prop(trait, "has broader", collapse = TRUE),
+      prop(trait, "has context object", label = "plant structure",
+           uri = paste0(IADOPT, "hasContextObject"),
+           collapse = TRUE, repeat_heading = TRUE),
+      prop(trait, "measured characteristic", collapse = TRUE),
+      prop(trait, "keyword", collapse = TRUE, skip_if_empty = TRUE),
+      prop(trait, "scope note",
+           label = "scope note", uri = paste0(SKOS, "scopeNote")),
+      prop(trait, "has exact match", collapse = TRUE,
+           label = "has exact match", uri = paste0(SKOS, "exactMatch")),
+      prop(trait, "has close match", collapse = TRUE,
+           label = "has close match", uri = paste0(SKOS, "closeMatch")),
+      prop(trait, "has related match", collapse = TRUE,
+           label = "has related match", uri = paste0(SKOS, "relatedMatch")),
+      prop(trait, "example", collapse = TRUE,
+           label = "examples", uri = paste0(SKOS, "example")),
+      prop(trait, "references", collapse = TRUE,
+           label = "references", uri = paste0(DCTERMS, "references"),
+           default = "no linked references"),
+      prop(trait, "date created",
+           label = "date created", uri = paste0(DCTERMS, "created")),
+      prop(trait, "date modified",
+           label = "date modified", uri = paste0(DCTERMS, "modified")),
+      prop(trait, "date reviewed",
+           label = "date reviewed", uri = paste0(DCTERMS, "reviewed")),
+      prop(trait, "reviewed by", collapse = TRUE,
+           label = "reviewed by", uri = paste0(DATACITE, "IsReviewedBy"),
+           default = "no reviewers"),
+      prop(trait, "change note",
+           label = "change note", uri = paste0(SKOS, "changeNote")),
+      prop(trait, "is in scheme"),
+      prop(trait, "identifier")
     )
-
-  # references
-  references_tmp <- trait_i %>% filter(property == "references")
-
-  if(nrow(references_tmp) == 0) {
-    references_tmp <- NULL
-    references_tmp$value_link <- "no linked references"
-  }
-
-  output <-
-    add_row(output,
-            make_link("references","http://purl.org/dc/terms/references"),
-            print_list2(references_tmp$value_link)
-            )
-  
-  # date created
-  date_created <- trait_i %>% filter(property == "date created")
-
-  output <-
-    add_row(output,
-            make_link("date created","http://purl.org/dc/terms/created"),
-            date_created$value_link
-            )
-
-  # date modified
-  date_modified <- trait_i %>% filter(property == "date modified")
-
-  output <-
-    add_row(output,
-            make_link("date modified","http://purl.org/dc/terms/modified"),
-            date_modified$value_link
-            )
-
-  # date reviewed
-  date_reviewed <- trait_i %>% filter(property == "date reviewed")
-
-  output <-
-    add_row(output,
-            make_link("date reviewed","http://purl.org/dc/terms/reviewed"),
-            date_reviewed$value_link
-            )
-
-  # reviewers - PROBLEM; print_list2
-  reviewers_tmp <- trait_i %>% filter(property == "reviewed by")
-
-  if(nrow(reviewers_tmp) == 0) {
-    reviewers_tmp <- NULL
-    reviewers_tmp$value_link <- "no reviewers"
-  }
-
-  output <-
-    add_row(output,
-            make_link("reviewed by", "http://purl.org/datacite/v4.4/IsReviewedBy"),
-            print_list2(reviewers_tmp$value_link)
-            )
-
-  # deprecated names (change note)
-  
-  change_tmp <- trait_i %>% filter(property == "change note")
-  
-  output <-
-    add_row(output, 
-            make_link("change note", "http://www.w3.org/2004/02/skos/core#changeNote"),
-            change_tmp$value_link
-            )
-
-  # in scheme
-  scheme <- trait_i %>% filter(property == "is in scheme")
-  
-  output <-
-    add_row(output,
-            scheme$property_link,
-            scheme$value_link
-            )
-  
-  
-  # identifier
-  identifier <- trait_i %>% filter(property == "identifier")
-  
-  output <-
-    add_row(output,
-            identifier$property_link,
-            identifier$value_link
-            )
-  
-  output
+  ))
 }
 
-# trait hierarchy table
-
+#' Build the table for one trait group
+#'
+#' Trait groups are the hierarchy layer above trait concepts: each names the
+#' traits below it, so the table is mostly the `has narrower` list. Produces
+#' section 2 of the dictionary, "Trait groups".
+#'
+#' @param thistrait URI of the group, e.g.
+#'   `https://w3id.org/APD/traits/trait_group_0000008`.
+#' @param triples_with_labels The labelled triple table.
+#' @return A tibble of `name` and `description` list-columns.
 create_APD_trait_hierarchy_table <- function(thistrait, triples_with_labels) {
-  
-  trait_i <- 
-    triples_with_labels %>% 
-    filter(Subject == thistrait) %>%
-    mutate(property_link = NA, value_link = NA)
-  
-  
-  for (i in seq_len(nrow(trait_i))) {
-    trait_i$property_link[i] <- make_link(trait_i$property[i], trait_i$Predicate[i])
-    trait_i$value_link[i] = ifelse(!is.na(trait_i$Object[i]), make_link(trait_i$value[i], trait_i$Object[i]), trait_i$value[i])
-  }
-  
-  output <- tibble(name =  list(), description = list())
-  
-  output <- 
-    add_row(output, "URI", trait_i$Subject[1])
-  
-  # label
-    label_tmp <- trait_i %>% filter(property == "preferred label")
-    
-    output <-
-      add_row(output,
-              label_tmp$property_link,
-              label_tmp$value_link
-      )
-  
-  
-  # description
-    description_tmp <- trait_i %>% filter(property == "description")
-    
-    output <-
-      add_row(output, 
-              description_tmp$property_link, 
-              description_tmp$value_link
-              )
-  
-  
-  # traits within group (has narrower)
-    narrower_tmp <- trait_i %>% filter(property == "has narrower")
-    
-    if (nrow(narrower_tmp) > 0) {
-    output <-
-      add_row(output, 
-              narrower_tmp$property_link[1],
-              print_list2(narrower_tmp$value_link)
-              ) 
-    }
-    
-  
-  # trait grouping (has broader)
-    grouping <- trait_i %>% filter(property == "has broader")
-    
-    if (nrow(grouping) > 0) {
-    output <-
-      add_row(output, 
-              grouping$property_link[1],
-              print_list2(grouping$value_link)
-              ) 
-    }
-  
-  # in scheme
-    scheme_tmp <- trait_i %>% filter(property == "is in scheme")
-    
-    output <-
-      add_row(output,
-              scheme_tmp$property_link,
-              scheme_tmp$value_link
-      )
-    
-  
-  # identifier
-    identifier_tmp <- trait_i %>% filter(property == "identifier")
-    
-    output <-
-      add_row(output,
-              identifier_tmp$property_link,
-              identifier_tmp$value_link
-      )
-    
-  output
+
+  group <- apd_entity_rows(triples_with_labels, thistrait)
+
+  property_table(list(
+    literal_prop("URI", group$Subject[1]),
+    prop(group, "preferred label"),
+    prop(group, "description"),
+    # The top of the hierarchy has no parent and the bottom no children, so
+    # unlike everywhere else these pairs are omitted rather than left empty.
+    prop(group, "has narrower", collapse = TRUE, skip_if_empty = TRUE),
+    prop(group, "has broader", collapse = TRUE, skip_if_empty = TRUE),
+    prop(group, "is in scheme"),
+    prop(group, "identifier")
+  ))
 }
 
-
-# categorical values
+#' Build the table for one allowable categorical value
+#'
+#' The 819 allowed values of the categorical traits, each defined once and linked
+#' to the single trait it belongs to, so that the same word used by two traits
+#' does not become ambiguous. Produces section 4 of the dictionary, "Values for
+#' categorical traits".
+#'
+#' The odd one out of the four: it takes a bare slug rather than a URI, because
+#' `index.qmd` has already stripped the base off to use as the page anchor.
+#'
+#' @param thistrait Slug of the value, e.g. `plant_growth_form_tree` -- not a
+#'   full URI.
+#' @param triples_with_labels The labelled triple table.
+#' @return A tibble of `name` and `description` list-columns.
 create_APD_categorical_values_table <- function(thistrait, triples_with_labels) {
-  
+
   thistrait <- paste0("https://w3id.org/APD/traits/", thistrait)
-  
-  trait_i <- 
-    triples_with_labels %>% 
-    filter(Subject_stripped == thistrait) %>%
-    mutate(property_link = NA, value_link = NA)
-  
-  
-  for (i in seq_len(nrow(trait_i))) {
-    trait_i$property_link[i] <- make_link(trait_i$property[i], trait_i$Predicate[i])
-    trait_i$value_link[i] = ifelse(!is.na(trait_i$Object[i]), make_link(trait_i$value[i], trait_i$Object[i]), trait_i$value[i])
-  }
-  
-  output <- tibble(name =  list(), description = list())
-  
-  output <- 
-    add_row(output, "URI", trait_i$Subject[1])
-  
-  # label
-  label_tmp <- trait_i %>% filter(property == "preferred label")
-  
-  output <-
-    add_row(output,
-            label_tmp$property_link,
-            label_tmp$value_link
-    )
-  
-  
-  # description
-  description_tmp <- trait_i %>% filter(property == "description")
-  
-  output <-
-    add_row(output, 
-            description_tmp$property_link, 
-            description_tmp$value_link
-    )
-  
-  # in scheme
-  broader_tmp <- trait_i %>% filter(property == "has broader")
-  
-  output <-
-    add_row(output,
-            broader_tmp$property_link[1],
-            broader_tmp$value_link
-    )
-  
-  # in scheme
-  scheme_tmp <- trait_i %>% filter(property == "is in scheme")
-  
-  output <-
-    add_row(output,
-            scheme_tmp$property_link,
-            scheme_tmp$value_link
-    )
-  
-  
-  # identifier
-  identifier_tmp <- trait_i %>% filter(property == "identifier")
-  
-  output <-
-    add_row(output,
-            identifier_tmp$property_link,
-            identifier_tmp$value_link
-    )
-  
-  output
+
+  value <- apd_entity_rows(triples_with_labels, thistrait,
+                           key = "Subject_stripped")
+
+  property_table(list(
+    literal_prop("URI", value$Subject[1]),
+    prop(value, "preferred label"),
+    prop(value, "description"),
+    # The trait this value belongs to: one heading, but the value shown as it
+    # comes rather than stacked, since there is only ever one parent.
+    prop(value, "has broader", heading = "first"),
+    prop(value, "is in scheme"),
+    prop(value, "identifier")
+  ))
 }
 
-# glossary terms
-
+#' Build the table for one glossary term
+#'
+#' The glossary holds terms used as keywords in trait descriptions that no other
+#' published vocabulary defines, so the APD has to define them itself. The
+#' smallest of the four tables. Produces section 5 of the dictionary, "Glossary".
+#'
+#' @param thistrait URI of the term, under `https://w3id.org/APD/glossary/`.
+#' @param triples_with_labels The labelled triple table.
+#' @return A tibble of `name` and `description` list-columns.
 create_APD_trait_glossary_table <- function(thistrait, triples_with_labels) {
-  
-  trait_i <- 
-    triples_with_labels %>% 
-    filter(Subject_stripped == thistrait) %>%
-    mutate(property_link = NA, value_link = NA)
-  
-  
-  for (i in seq_len(nrow(trait_i))) {
-    trait_i$property_link[i] <- make_link(trait_i$property[i], trait_i$Predicate[i])
-    trait_i$value_link[i] = ifelse(!is.na(trait_i$Object[i]), make_link(trait_i$value[i], trait_i$Object[i]), trait_i$value[i])
-  }
-  
-  output <- tibble(name =  list(), description = list())
-  
-  output <- 
-    add_row(output, "URI", trait_i$Subject[1])
-  
-  # label
-  label_tmp <- trait_i %>% filter(property == "preferred label")
-  
-  output <-
-    add_row(output,
-            label_tmp$property_link,
-            label_tmp$value_link
-    )
-  
-  
-  # description
-  description_tmp <- trait_i %>% filter(property == "description")
-  
-  output <-
-    add_row(output, 
-            description_tmp$property_link, 
-            description_tmp$value_link
-    )
-  
-  
-  # top concept
-  top_concept_tmp <- trait_i %>% filter(property == "top concept of")
-  
-  output <-
-    add_row(output,
-            top_concept_tmp$property_link,
-            top_concept_tmp$value_link
-    ) 
-  
-  # in scheme
-  scheme_tmp <- trait_i %>% filter(property == "is in scheme")
-  
-  output <-
-    add_row(output,
-            scheme_tmp$property_link,
-            scheme_tmp$value_link
-    )
-  
-  
-  # identifier
-  identifier_tmp <- trait_i %>% filter(property == "identifier")
-  
-  output <-
-    add_row(output,
-            identifier_tmp$property_link,
-            identifier_tmp$value_link
-    )
-  
-  output
+
+  term <- apd_entity_rows(triples_with_labels, thistrait,
+                          key = "Subject_stripped")
+
+  property_table(list(
+    literal_prop("URI", term$Subject[1]),
+    prop(term, "preferred label"),
+    prop(term, "description"),
+    prop(term, "top concept of"),
+    prop(term, "is in scheme"),
+    prop(term, "identifier")
+  ))
 }

--- a/R/flat_tables.R
+++ b/R/flat_tables.R
@@ -39,19 +39,13 @@ apd_collapse_field <- function(traits, field, out_name, decorate) {
                                 ~ stringr::str_split(.x, "; "))) %>%
     tidyr::unnest_wider(col = dplyr::all_of(field), names_sep = "_")
 
-  out <-
-    wide %>%
+  wide %>%
     tidyr::pivot_longer(cols = 2:ncol(wide)) %>%
     dplyr::filter(!is.na(value)) %>%
     dplyr::mutate(value = decorate(value)) %>%
     dplyr::group_by(trait) %>%
-    dplyr::mutate(collapsed = paste(value, collapse = "; ")) %>%
-    dplyr::ungroup() %>%
-    dplyr::select(-dplyr::all_of(c("name", "value"))) %>%
-    dplyr::distinct()
-
-  names(out)[names(out) == "collapsed"] <- out_name
-  out
+    dplyr::summarise(!!out_name := paste(value, collapse = "; "),
+                     .groups = "drop")
 }
 
 # Look `keys` up in `table[[key_col]]` and return the matching `value_col`.
@@ -160,12 +154,9 @@ apd_traits_table <- function(inputs) {
     apd_trait_examples(traits)
   )
 
-  out <- core_traits
-  for (piece in collapsed) {
-    out <- dplyr::left_join(out, piece, by = "trait")
-  }
-
-  out %>% dplyr::select(dplyr::all_of(APD_TRAITS_TABLE_COLUMNS))
+  collapsed %>%
+    purrr::reduce(dplyr::left_join, by = "trait", .init = core_traits) %>%
+    dplyr::select(dplyr::all_of(APD_TRAITS_TABLE_COLUMNS))
 }
 
 #' Collapse the per-vocabulary mapping columns into one `examples` column
@@ -201,10 +192,8 @@ apd_trait_examples <- function(traits) {
     tidyr::pivot_longer(cols = 2:ncol(wide)) %>%
     dplyr::filter(!is.na(value)) %>%
     dplyr::group_by(trait) %>%
-    dplyr::mutate(examples = paste(value, collapse = "; ")) %>%
-    dplyr::ungroup() %>%
-    dplyr::select(-dplyr::all_of(c("name", "value"))) %>%
-    dplyr::distinct()
+    dplyr::summarise(examples = paste(value, collapse = "; "),
+                     .groups = "drop")
 }
 
 #' Build the published table of allowable categorical values

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -57,17 +57,21 @@ make_link <- function(text, url) {
 }
 
 
-
-
-print_list2 <- function(vals) {
-  
-  out <- c()
-  
+#' Stack several values into one HTML cell
+#'
+#' A property can hold a list -- several keywords, several references -- and all
+#' of them share one `<dd>`, one per line. `NA`s are dropped rather than printed,
+#' and a property with nothing left is returned as `NULL` so that
+#' `apd_definition_list()` omits the row entirely.
+#'
+#' @param vals A character vector of already-rendered values.
+#' @return A single HTML string, or `NULL` if there was nothing to show.
+html_lines <- function(vals) {
   vals <- vals[!is.na(vals)]
-  
-  if (length(vals) > 0) {
-    out <- c(out, paste0(vals, collapse = "<br>\n"))
-  } 
-  
-  out
+
+  if (length(vals) == 0) {
+    return(NULL)
+  }
+
+  paste(vals, collapse = "<br>\n")
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -16,9 +16,12 @@ APD_KNOWN_GAPS <- c(
   `rdf-datatype-relative-uri` = paste(
     "1,371 statements are typed '^^<xsd:date>' or '^^<xsd:anyURI>' -- a prefixed",
     "name where RDF requires an absolute URI, so it resolves as a relative",
-    "reference instead of the XSD datatype. R/convert_to_triples.R:201,243-245.",
-    "The dates are also M/D/YYYY, not ISO 8601, so correcting the datatype URI",
-    "alone would make them invalidly typed."
+    "reference instead of the XSD datatype. R/convert_to_triples.R:225,269-271.",
+    "The dates are also DD/MM/YYYY, not ISO 8601, so correcting the datatype URI",
+    "alone would make them invalidly typed. The two have to be fixed together.",
+    "Day-first is unambiguous and consistent -- 764 of the 1,353 values have a",
+    "first component above 12 and none has a second above 12 -- so reformatting",
+    "is deterministic, not a judgement call. Tracked in APD#59."
   ),
   `namespace-no-delimiter` = paste(
     "SWEET_propConductivity is declared without a trailing '/', so the URIs",
@@ -29,11 +32,13 @@ APD_KNOWN_GAPS <- c(
     "them changes how APD.ttl abbreviates those URIs."
   ),
   `input-duplicate-key` = paste(
-    "data/APD_units.csv has `[ppm]` on two rows with different labels and URIs",
-    "(the second is parts per thousand, and should be `[ppth]`), so the",
-    "published RDF asserts the wrong identifier for that unit.",
-    "published_classes.csv has four duplicated identifiers, two on rows that",
-    "disagree. Needs a maintainer decision on which row wins."
+    "data/APD_units.csv has `[ppm]` in the `identifier` cell of two rows. The",
+    "second row is parts per thousand and its URI, label and UCUM code all say",
+    "so; only that one cell is a typo for `[ppth]`. Nothing in the build reads",
+    "the column -- units are matched on `label` and `Entity` -- so the published",
+    "RDF is correct and fixing it changes no output. published_classes.csv is the",
+    "real gap: four duplicated identifiers, two on rows that disagree, which does",
+    "need a decision on which row wins. Tracked in APD#59."
   ),
   `input-redundant-row` = paste(
     "published_classes.csv repeats four identifiers on rows that are otherwise",
@@ -50,8 +55,12 @@ APD_KNOWN_GAPS <- c(
   `unresolved-identifier` = paste(
     "TO_0000432 (4 traits) and ENVO:01001125 (1 trait) are referenced as",
     "keywords but are absent from published_classes.csv, so they publish as",
-    "'NA [id]'. ENVO:01001125 also uses ':' where the ENVO entries in that file",
-    "use '_'. Adding them needs the labels from the source ontologies."
+    "'NA [id]'. Adding them needs the labels from the source ontologies, or a",
+    "decision to drop the keyword. Tracked in APD#59. The register used to say",
+    "ENVO:01001125 was also punctuated wrongly, using ':' where 'the ENVO",
+    "entries in that file use _'; there are no ENVO entries in that file, and it",
+    "already carries 95 colon-style identifiers against 657 underscore-style, so",
+    "the punctuation is not part of the problem."
   )
 )
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # The AusTraits Plant Dictionary (APD)
 
 <!-- badges: start -->
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8040789.svg)](https://doi.org/10.5281/zenodo.8040789)
+<!-- The DOI badge is served by shields.io, not zenodo.org/badge/DOI/. Zenodo
+     rate-limits GitHub's image proxy, which then serves the string "Invalid
+     upstream response (429)" in place of the SVG and the badge renders broken.
+     index.qmd already used shields.io for this same DOI. -->
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.8040789-blue.svg)](https://doi.org/10.5281/zenodo.8040789)
+[![check](https://github.com/traitecoevo/APD/actions/workflows/check.yml/badge.svg)](https://github.com/traitecoevo/APD/actions/workflows/check.yml)
 <!-- badges: end -->
 
 ![](inst/figures/logo.png)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,9 @@ git checkout develop && git pull
 
 - Bump `Version:` in `DESCRIPTION`.
 - Add a `## APD Version <X.Y.Z>` section to `NEWS.md`. `make release` refuses without one, and the
-  section immediately below yours is what the site publishes as "Previous version".
+  section immediately below yours is what the site publishes as "Previous version". If there is an
+  `## Unreleased` section at the top, rename *it* rather than adding another — changes land there
+  between releases, and only the `## APD Version` form is matched by the version checks.
 - Note anything breaking, and anything that closes a gap in `COMMITMENTS.md`.
 
 ```bash

--- a/index.qmd
+++ b/index.qmd
@@ -194,7 +194,7 @@ to_match_tmp <- triples_with_labels %>%
  
 for (thistrait in list_of_traits[[1]]) {
   
-  # creating header makes anchor using header name. Aslo create an anchor using trait_ID
+  # creating header makes anchor using header name. Also create an anchor using trait_ID
   term_to_display <- to_match_tmp$value[match(thistrait,to_match_tmp$Subject_stripped)]
   anchor <- gsub(base_url_traits, "", thistrait, fixed = TRUE)
   writeLines(sprintf('\n\n <span id="%s"> </span>\n\n## %s ', anchor, term_to_display))
@@ -230,8 +230,9 @@ categorical_allowed <-
     filter(Subject_stripped %in% to_match_tmp$Subject_stripped) %>%
     filter(property == "has broader") %>%
     select(Subject_stripped, trait_name = value) %>%
-    left_join(to_match_tmp) %>%
-    left_join(categorical_allowed %>% rename(Subject_stripped = identifier)) %>%
+    left_join(to_match_tmp, by = "Subject_stripped") %>%
+    left_join(categorical_allowed %>% rename(Subject_stripped = identifier),
+              by = "Subject_stripped") %>%
     arrange(Object)
  
   traits_names_tmp <- tmp_categorical2 %>%
@@ -240,25 +241,29 @@ categorical_allowed <-
 for (thistrait in traits_names_tmp$trait_name) {
 
   writeLines(paste0("\n## ", thistrait, "\n\n"))
-  
-  tmp_cat_select <- tmp_categorical2 %>% 
-    filter(trait_name == thistrait)
-  
-  cat_for_trait <- as.data.frame(categorical_allowed) %>% filter(categorical_allowed$identifier %in% tmp_cat_select$Subject_stripped)
-  
-  for (cat_val in cat_for_trait$identifier) {
-  
-  # creating header makes anchor using header name. Aslo create an anchor using trait_ID
-  term_to_display <- to_match_tmp$value[match(cat_val, to_match_tmp$Subject_stripped)]
-  anchor <- gsub(base_url_traits, "", cat_val, fixed = TRUE)    
-  writeLines(sprintf('\n\n <span id="%s"> </span>\n\n## %s ', anchor, term_to_display))
 
-  out <- 
+  tmp_cat_select <- tmp_categorical2 %>%
+    filter(trait_name == thistrait)
+
+  cat_for_trait <- categorical_allowed %>%
+    filter(identifier %in% tmp_cat_select$Subject_stripped)
+
+  for (cat_val in cat_for_trait$identifier) {
+
+  # An allowed value belongs to the trait above it, so it is a level deeper.
+  # Both were `##`, which made the 819 values siblings of the 115 traits that
+  # own them -- one flat run in the TOC, and no way to collapse a trait.
+  # `toc-expand: 1` now leaves them folded until a trait is opened.
+  term_to_display <- to_match_tmp$value[match(cat_val, to_match_tmp$Subject_stripped)]
+  anchor <- gsub(base_url_traits, "", cat_val, fixed = TRUE)
+  writeLines(sprintf('\n\n <span id="%s"> </span>\n\n### %s ', anchor, term_to_display))
+
+  out <-
       create_APD_categorical_values_table(anchor, triples_with_labels)
-  
+
   out %>% print_table()
   }
-  
+
 }
   
 ```
@@ -275,14 +280,14 @@ glossary_terms <-
   filter(stringr::str_detect(Subject, "glossary_")) %>%
   select(identifier = Subject)
 
-for (thistrait in glossary_terms$identifier) {
-  
-  to_match_tmp <- triples_with_labels %>% 
-    filter(Subject_stripped %in% glossary_terms$identifier) %>%
-    filter(property == "preferred label") %>%
-    select(Subject_stripped, value)
+to_match_tmp <- triples_with_labels %>%
+  filter(Subject_stripped %in% glossary_terms$identifier) %>%
+  filter(property == "preferred label") %>%
+  select(Subject_stripped, value)
 
-  # creating header makes anchor using header name. Aslo create an anchor using trait_ID  
+for (thistrait in glossary_terms$identifier) {
+
+  # creating header makes anchor using header name. Also create an anchor using trait_ID
   term_to_display <- to_match_tmp$value[match(thistrait, to_match_tmp$Subject_stripped)]
   anchor <- gsub(base_url_glossary, "", thistrait, fixed = TRUE)
   writeLines(sprintf('\n\n <span id="%s"> </span>\n\n## %s ', anchor, term_to_display))
@@ -290,7 +295,7 @@ for (thistrait in glossary_terms$identifier) {
   out <- 
     create_APD_trait_glossary_table(thistrait, triples_with_labels)
 
-  out %>% print_table()#150, 500)
+  out %>% print_table()
 }
 ```
 

--- a/scripts/build_data.R
+++ b/scripts/build_data.R
@@ -2,7 +2,7 @@
 # `make data` -- build the dictionary from data/.
 #
 # Writes APD_triples.csv, the four RDF serialisations (APD.nq/.nt/.ttl/.json) and
-# the two flat CSVs, all at the repo root. Reads data/ and writes nothing to it.
+# the two flat CSVs, all into export/. Reads data/ and writes nothing to it.
 
 source("scripts/setup.R")
 

--- a/scripts/release.R
+++ b/scripts/release.R
@@ -28,8 +28,8 @@ message("Releasing version ", version,
 # --- snapshot ----------------------------------------------------------------
 #
 # One snapshot tree, in release/. docs/release/ used to hold a byte-identical
-# copy written here as well; it is now populated on render instead, because
-# _quarto.yml lists `release` as a site resource.
+# copy written here as well; .github/workflows/deploy.yml copies it in after the
+# render instead, so a local `make site` yields a docs/ without it.
 
 # APD_traits_input.csv is no longer tracked in git -- the YAML is the source of
 # truth and a second tracked copy is a second source of truth. But Wenk et al.
@@ -39,9 +39,8 @@ message("Releasing version ", version,
 message("Exporting ", basename(TRAITS_CSV), " for the release")
 convert_APD_traits_input_yml_to_csv()
 
-# Where each release file is found. Everything built at the root is also copied
-# into docs/ by quarto, so the root copy is the one to take; index.html only
-# exists once rendered.
+# Where each release file is found. The build products are taken from export/,
+# which is where `make data` writes them; index.html only exists once rendered.
 RELEASE_FILES <- c(
   file.path(APD_EXPORT_DIR, setdiff(APD_OUTPUTS, "APD_triples.csv")),
   file.path("docs", "index.html"),

--- a/scripts/sparql_examples.R
+++ b/scripts/sparql_examples.R
@@ -10,11 +10,13 @@
 source("scripts/setup.R")
 apd_require("stringi")
 
-if (!file.exists("APD.nq")) {
-  stop("APD.nq does not exist. Run `make data` first.", call. = FALSE)
+nq <- file.path(APD_EXPORT_DIR, "APD.nq")
+
+if (!file.exists(nq)) {
+  stop(nq, " does not exist. Run `make data` first.", call. = FALSE)
 }
 
-graph <- rdflib::rdf_parse("APD.nq", format = "nquads")
+graph <- rdflib::rdf_parse(nq, format = "nquads")
 
 # rdflib writes non-ASCII as "<U+00E9>" escapes, so labels need unescaping to be
 # readable -- see the iconv() call in convert_to_triples.R.


### PR DESCRIPTION
Closes #49.

A review of every `.R` and `.qmd` file for simplifications, which turned into work on the two files #49 asks to document — `R/convert_to_triples.R` and `R/create_APD_trait_table.R` were the two #48 left untouched, and between them held nearly all the duplication in `R/`.

Four commits, deliberately separate: the first is provably output-neutral, the third is the only one that changes the page.

## 1. Simplify and document the two files (#49)

`create_APD_trait_table.R` was 22 near-identical six-line blocks differing only in which property they selected and how the value was formatted. Each builder is now a list of `prop()` calls, one per property, in page order — the defaults describe the common case, so a call site names only its departure from it:

```r
prop(trait, "description", collapse = TRUE),
prop(trait, "minAllowedValue", column = "value"),
prop(trait, "reviewed by", collapse = TRUE,
     label = "reviewed by", uri = paste0(DATACITE, "IsReviewedBy"),
     default = "no reviewers"),
```

**Code lines 352 → 166**, while gaining 156 lines of documentation. Two things fell out of it:

- **`add_row()` is gone rather than renamed.** Nothing outside the file ever called it, so it can no longer shadow `dplyr::add_row()` — which it did for the entire build, `setup.R` attaching dplyr before `R/` is sourced.
- **Entity-table build 13.7 s → 7.0 s (1.96x)**, ~9% off the render, from building each table in one `tibble()` call instead of ~25 `bind_rows()` appends. Worth recording that the *obvious* optimisation here — vectorising the per-row `make_link()` loop — measured 1.04x, i.e. nothing.

In `convert_to_triples.R`: nine copies of `pivot_longer() %>% rename(Predicate = name, Object = value)` became one call with `names_to`/`values_to`; three copies of the broader→narrower swap became `as_narrower()`. The `example` columns were numbered by `seq_along(1:length(...))` re-selecting from the variable the pipe started from, which only agreed by luck — it now counts the columns it was handed.

Per the #49 convention: `#'` blocks with a *why* paragraph plus `@param`/`@return`, no `@export`, no `@examples`. The salvaged text from the deleted `roxygen` branch needed its `@param` lines rewritten (they restated the argument names) and its `@return` corrected — the function returns a two-element list, not "a data frame or list".

### Verified output-neutral, three ways

- `test-golden.R` — byte-for-byte against the committed `export/`
- the 1,473-entity markup digest in `test-entity-tables.R`
- a full render: `docs/index.html` has the **same SHA-256** before and after

The digest earned its keep. My first attempt changed it, because `plant_structure$property_link` is assigned *into the column* — so the "plant structure" label is deliberately recycled once per structure. A second attempt silently dropped the `date reviewed` and `change note` headings on the 543 traits lacking those properties. Both found and fixed before going further.

## 2. `sparql_examples.R` was dead

It looked for `APD.nq` at the repo root, so it has failed at its own "run `make data` first" guard ever since the artefacts moved into `export/`. It runs again — 38 predicates, 26 reviewers. Three comments in `build_data.R` and `release.R` had gone stale the same way, one of them claiming `_quarto.yml` still lists `release` as a site resource, which #55 removed.

## 3. Nest categorical values in the contents ⚠️ changes the page

In section 4, each of the 819 allowable values was headed at the same level as the 115 traits that own them, so the contents listed all 934 as one flat run — a value indistinguishable from a trait, and no way to collapse one. Values are one level deeper now, so `toc-expand: 1` leaves them folded until a trait is opened. Anchored `h2` 1589 → 770, `h3` 0 → 819.

No tracked artefact moves: `export/` is byte-identical and `docs/` is gitignored, so this needs no separate artefact commit. **All 1,473 anchors still resolve** — the explicit `<span id>` anchors the w3id rules target are untouched.

Recorded under a new `## Unreleased` heading in `NEWS.md`; **no version bump**, it ships with the next release. `apd_released_versions()` matches only `## APD Version <X.Y.Z>`, so that section is invisible to the version checks and to "Previous version" on the site — verified. That only holds while the heading keeps that form, so `RELEASING.md` now says to rename it at release time rather than adding a second section.

## 4. The README DOI badge rendered broken

Not a markdown problem — Zenodo rate-limits GitHub's camo image proxy, which then serves the literal string `Invalid upstream response (429)` in place of the SVG. Measured failing **3 times in 5** through camo, against **5 for 5** for the shields.io equivalent, which `index.qmd` already used for this same DOI. Added a `check` workflow badge while there.

---

`make check`: **1,566 pass, 0 fail**, the same 9 known gaps as `develop` — I diffed the gap output between the two branches and it is identical, so none of them is from this work.

## Deliberately not done

`prop()`'s `repeat_heading` and `heading = "first"` arguments each exist for exactly one caller, both preserving quirks of published output that are commented at the call site. Worth revisiting when those outputs are next changed on purpose, not before.

The remaining ~4.5 s of the entity-table build is per-entity filtering over the full triple table. Pre-splitting by `Subject` would be the next lever, but the builders are called one entity at a time from `index.qmd`, so it would mean changing their signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
