### PR TITLE
Make /APD/ the one URL for the dictionary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,15 @@ al. 2024, doi:10.1038/s41597-024-03368-z).
   which would publish them under `export/` and break every existing link. See COMMITMENTS.md C12.
 - **Website:** a Quarto website (`_quarto.yml`, `index.qmd`, `using_the_APD.qmd`, `NEWS.md`) rendered
   to `docs/` and published via GitHub Pages at <https://traitecoevo.github.io/APD/>. The dictionary
-  is also resolvable via <https://w3id.org/APD/>. **`docs/` is gitignored** — a local build artefact
+  is also resolvable via <https://w3id.org/APD/>.
+
+  **Never add a `<link href=...>` via `include-in-header`.** Every page sets `embed-resources: true`,
+  and that pass inlines any `<link>` target it can resolve. Adding a `rel="canonical"` link that way
+  made quarto **fetch the live site and embed all 6 MB of it as a `data:` URI** — the page went from
+  6.1 MB to 15.2 MB and the `href` was replaced by the inlined document. Anything that has to reach
+  the `<head>` of these pages gets added *after* the render, in `scripts/build_site.R`.
+
+  **`docs/` is gitignored** — a local build artefact
   like `export/`. `deploy.yml` renders it fresh on `master`; nothing reads the committed tree, because
   there isn't one. It also carries `release/`, which is *not* a quarto resource any more, so a local
   `make site` yields a `docs/` without the versioned snapshots. That is expected.

--- a/R/site.R
+++ b/R/site.R
@@ -3,7 +3,7 @@
 # The dictionary is one document, so every one of the 1,473 published
 # identifiers resolves to a fragment of it: w3id.org sends
 # https://w3id.org/APD/traits/trait_0000012 to
-# https://traitecoevo.github.io/APD/index.html#trait_0000012. An entity that
+# https://traitecoevo.github.io/APD/#trait_0000012. An entity that
 # renders without its anchor therefore does not stop being published -- it stops
 # being findable, and the URI silently scrolls to the top of the page instead.
 # That is gap C1 in COMMITMENTS.md, currently true for the 819 categorical
@@ -55,4 +55,117 @@ apd_missing_anchors <- function(html = file.path("docs", "index.html"),
                   logical(1), USE.NAMES = FALSE)
 
   slugs[!found]
+}
+
+#' Make the search index point at the document, not at `index.html`
+#'
+#' The dictionary has two URLs -- `/APD/` and `/APD/index.html` -- serving one
+#' byte-identical 6 MB document. The browser cache is keyed on URL, so a visitor
+#' who reaches it both ways downloads it twice, and every navigation between the
+#' two forms is a full reload rather than a jump.
+#'
+#' `/APD/` is the canonical form: it is what `site-url` declares, what the
+#' w3id.org rules redirect to, and what the page's own 6,366 internal links
+#' resolve to. Quarto's search index is the one thing that disagrees -- it
+#' writes `"href": "index.html#<frag>"` for every entry on this page, so a
+#' search result clicked from `/APD/` changes the path and reloads the whole
+#' document.
+#'
+#' The fix is to drop `index.html` and let Quarto's own offset supply the path.
+#' Its search code does `offsetURL(item.href)`, which prepends
+#' `<meta name="quarto:offset">` -- `./` for every page on this flat site. So a
+#' bare `#frag` becomes `./#frag`, and that resolves correctly from everywhere:
+#'
+#' | from                | `./#frag` resolves to | reload |
+#' |---------------------|-----------------------|--------|
+#' | `/APD/`             | `/APD/#frag`          | no     |
+#' | `/APD/news.html`    | `/APD/#frag`          | yes -- different document |
+#' | `quarto preview` at `/` | `/#frag`          | no     |
+#'
+#' Deliberately *not* rewritten to `/APD/#frag`: hardcoding the site path would
+#' break `quarto preview`, which serves the project at `/`.
+#'
+#' Text substitution rather than a JSON round trip, so the diff is confined to
+#' the field being changed and no `jsonlite` dependency is added for one edit.
+#'
+#' @param path Path to the rendered `search.json`.
+#' @return The number of hrefs rewritten, invisibly.
+apd_canonicalise_search_hrefs <- function(path = file.path("docs",
+                                                           "search.json")) {
+
+  if (!file.exists(path)) {
+    return(invisible(0L))
+  }
+
+  before <- readr::read_file(path)
+  key <- '("href"[[:space:]]*:[[:space:]]*")'
+
+  # `index.html#frag` -> `#frag`, then the single bare `index.html` -> `#`. The
+  # bare one cannot become an empty string: Quarto guards on `if (item.href)`,
+  # so an empty href would drop that result entirely.
+  after <- gsub(paste0(key, 'index\\.html(#[^"]*)"'), '\\1\\2"', before)
+  after <- gsub(paste0(key, 'index\\.html"'), '\\1#"', after)
+
+  n <- lengths(regmatches(before,
+                          gregexpr(paste0(key, "index\\.html"), before)))
+
+  if (n > 0) {
+    readr::write_file(after, path)
+  }
+
+  invisible(as.integer(n))
+}
+
+#' The URL this site declares as its own
+#'
+#' Single source for it: `_quarto.yml` already needs `site-url` for
+#' `sitemap.xml` and the search offset, so nothing else should repeat it.
+#'
+#' @param path Path to `_quarto.yml`.
+#' @return The site URL, with a trailing slash.
+apd_site_url <- function(path = "_quarto.yml") {
+  url <- yaml::read_yaml(path)$website$`site-url`
+  if (is.null(url)) stop("no website: site-url in ", path, call. = FALSE)
+  sub("/*$", "/", url)
+}
+
+#' Declare which of the document's two URLs is the real one
+#'
+#' `/APD/` and `/APD/index.html` serve byte-identical bytes, so both can be
+#' indexed and inbound links split between them. This says `/APD/` wins.
+#'
+#' **This has to run after the render, not from `include-in-header`.** Quarto's
+#' `embed-resources` pass treats every `<link href>` as a resource to inline, so
+#' declaring the canonical link in the front matter made it fetch the live site
+#' and embed all 6 MB of it as a `data:` URI. The page went 6.1 MB -> 15.2 MB
+#' and the `href` was replaced by the inlined document, leaving
+#' `rel="canonical"` attached to nothing. Post-processing is the only way to get
+#' a `<link>` into one of these pages intact.
+#'
+#' @param html Path to the rendered page.
+#' @param url The canonical URL.
+#' @return `TRUE` if the link was added, `FALSE` if it was already there.
+apd_add_canonical_link <- function(html = file.path("docs", "index.html"),
+                                   url = apd_site_url()) {
+
+  if (!file.exists(html)) {
+    stop(html, " does not exist -- run `make site` first.", call. = FALSE)
+  }
+
+  page <- readr::read_file(html)
+  link <- sprintf('<link rel="canonical" href="%s">', url)
+
+  if (grepl(link, page, fixed = TRUE)) {
+    return(invisible(FALSE))
+  }
+
+  if (!grepl("</head>", page, fixed = TRUE)) {
+    stop("no </head> in ", html, call. = FALSE)
+  }
+
+  # sub() replaces the first match only, which is the one we want.
+  readr::write_file(sub("</head>", paste0(link, "\n</head>"), page,
+                        fixed = TRUE), html)
+
+  invisible(TRUE)
 }

--- a/index.qmd
+++ b/index.qmd
@@ -15,6 +15,11 @@ format:
     toc: true
     toc-expand: 1
     embed-resources: true
+    # The canonical <link> is NOT declared here. `embed-resources` treats every
+    # <link href> as a resource to inline, so putting it in the header made
+    # quarto fetch the live site and embed all 6 MB of it as a data: URI --
+    # the page went from 6.1 MB to 15.2 MB and the href was replaced by the
+    # inlined document. scripts/build_site.R adds it after the render instead.
 ---
 
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}

--- a/scripts/build_site.R
+++ b/scripts/build_site.R
@@ -55,6 +55,20 @@ if (!all(copied)) {
 # a missing anchor turns a citable identifier into a scroll to the top of the
 # page. Checked here rather than in `make check`, because it is a property of
 # the render and nothing else produces it. See R/site.R.
+# The search index is the one part of the render that names index.html, which
+# would make every search result a 6 MB reload for anyone on the canonical
+# /APD/. See R/site.R for why a bare fragment is the right target.
+rewritten <- apd_canonicalise_search_hrefs()
+message("Pointed ", rewritten, " search hrefs at the document rather than ",
+        "index.html")
+
+# Declares /APD/ as the real URL of the two that serve this document. Has to be
+# done here rather than in index.qmd's header: `embed-resources` inlines every
+# <link href> it finds, and given the canonical link it fetched the live site
+# and embedded 6 MB of it. See R/site.R.
+apd_add_canonical_link()
+message("Declared ", apd_site_url(), " as the canonical URL")
+
 slugs <- apd_entity_slugs()
 missing_anchors <- apd_missing_anchors(slugs = slugs)
 

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -43,3 +43,97 @@ test_that("a missing render fails rather than reporting every entity missing", {
                                    slugs = "trait_0000012"),
                "run `make site`")
 })
+
+
+# --- the canonical URL -------------------------------------------------------
+#
+# /APD/ and /APD/index.html serve one byte-identical 6 MB document. Anything
+# that names the second splits inbound links and search-engine indexing across
+# two URLs, and turns a jump within the page into a full reload.
+
+test_that("the search index points at the document, not at index.html", {
+  json <- withr::local_tempfile(fileext = ".json")
+  writeLines(c(
+    '[',
+    '  { "objectID": "index.html", "href": "index.html" },',
+    '  { "objectID": "index.html#a", "href": "index.html#trait_0000012" },',
+    '  { "objectID": "news.html#b", "href": "news.html#apd-version-2.1.1" }',
+    ']'
+  ), json)
+
+  expect_identical(apd_canonicalise_search_hrefs(json), 2L)
+
+  after <- readr::read_file(json)
+
+  # The bare entry becomes "#", never "": quarto guards on `if (item.href)`, so
+  # an empty href would silently drop that result.
+  expect_match(after, '"href": "#"', fixed = TRUE)
+  expect_match(after, '"href": "#trait_0000012"', fixed = TRUE)
+
+  # Other pages are left alone -- a bare fragment there would scroll the wrong
+  # document instead of navigating to the dictionary.
+  expect_match(after, '"href": "news.html#apd-version-2.1.1"', fixed = TRUE)
+
+  # No href names index.html any more. `objectID` still does, and should: it is
+  # fuse's index key, not a navigation target.
+  hrefs <- regmatches(after, gregexpr('"href": "[^"]*"', after))[[1]]
+  expect_false(any(grepl("index.html", hrefs, fixed = TRUE)))
+  expect_match(after, '"objectID": "index.html"', fixed = TRUE)
+})
+
+test_that("rewriting the search index is idempotent and safe when absent", {
+  json <- withr::local_tempfile(fileext = ".json")
+  writeLines('[{ "href": "index.html#x" }]', json)
+
+  expect_identical(apd_canonicalise_search_hrefs(json), 1L)
+  once <- readr::read_file(json)
+  expect_identical(apd_canonicalise_search_hrefs(json), 0L)
+  expect_identical(readr::read_file(json), once)
+
+  # `search: false` would mean no index at all; that must not fail the render.
+  expect_identical(
+    apd_canonicalise_search_hrefs(file.path(tempdir(), "no-such.json")), 0L
+  )
+})
+
+test_that("the canonical URL comes from site-url, with a trailing slash", {
+  withr::local_dir(APD_ROOT)
+
+  expect_identical(apd_site_url(), "https://traitecoevo.github.io/APD/")
+
+  no_slash <- withr::local_tempfile(fileext = ".yml")
+  writeLines(c("website:", "  site-url: https://example.org/X"), no_slash)
+  expect_identical(apd_site_url(no_slash), "https://example.org/X/")
+
+  bare <- withr::local_tempfile(fileext = ".yml")
+  writeLines("project:\n  type: website", bare)
+  expect_error(apd_site_url(bare), "site-url")
+})
+
+test_that("the canonical link is added after the render, and only once", {
+  # It cannot come from index.qmd's include-in-header: `embed-resources` inlines
+  # every <link href>, so quarto fetched the live site and embedded 6 MB of it
+  # as a data: URI, taking the page from 6.1 MB to 15.2 MB and leaving
+  # rel="canonical" attached to the inlined document instead of a URL.
+  html <- withr::local_tempfile(fileext = ".html")
+  writeLines("<html><head><title>x</title></head><body></body></html>", html)
+
+  expect_true(apd_add_canonical_link(html, "https://example.org/X/"))
+
+  page <- readr::read_file(html)
+  expect_match(page, '<link rel="canonical" href="https://example.org/X/">',
+               fixed = TRUE)
+
+  # Idempotent: `make site` re-runs over an existing docs/.
+  expect_false(apd_add_canonical_link(html, "https://example.org/X/"))
+  expect_identical(
+    lengths(regmatches(readr::read_file(html),
+                       gregexpr("rel=\"canonical\"", readr::read_file(html)))),
+    1L
+  )
+
+  headless <- withr::local_tempfile(fileext = ".html")
+  writeLines("<html><body></body></html>", headless)
+  expect_error(apd_add_canonical_link(headless, "https://example.org/"),
+               "</head>")
+})


### PR DESCRIPTION
The APD half of the two-part fix. The w3id half is a separate PR to `perma-id/w3id.org`.

## The problem

`https://traitecoevo.github.io/APD/` and `.../APD/index.html` serve **one byte-identical 6 MB document** — same ETag. The browser cache is keyed on URL, so anyone who reaches it both ways downloads it twice, and crossing between the forms is a full reload rather than a jump. Nothing declared which one was real.

`/APD/` wins: it's what `site-url` declares, what the w3id rules now redirect to, and what the page's own 6,366 internal links resolve to.

## The search index was the actual reload

This is the part that wasn't obvious. All **1,590** entries for this page carried `"href": "index.html#<frag>"`, and Quarto navigates with `window.location.assign(offsetURL(item.href))` — so every search result clicked from `/APD/` changed the path and reloaded 6 MB. The search box is top-right on all three pages, so this is the main way anyone reaches a specific trait.

They're now bare `#<frag>`. Quarto's own `<meta name="quarto:offset">` is `./` on every page in this flat site, so `./#frag` resolves correctly from everywhere:

| clicked from | resolves to | reload |
|---|---|---|
| `/APD/` | `/APD/#frag` | **no** |
| `/APD/news.html` | `/APD/#frag` | yes — correctly, different document |
| `quarto preview` at `/` | `/#frag` | no |

Rewriting to a hardcoded `/APD/#frag` would have worked in production and broken `quarto preview`, which serves the project at `/`.

## `rel="canonical"` — the landmine

It **cannot** come from `index.qmd`'s `include-in-header`. `embed-resources: true` inlines every `<link href>` it can resolve, so given a canonical link **quarto fetched the live site and embedded all 6 MB of it as a `data:` URI**:

```
6,140,472 bytes  ->  15,200,714 bytes
17 data: blocks  ->  18, the new one 9,061,356 bytes of text/html
```

…and the `href` was replaced by the inlined document, leaving `rel="canonical"` attached to nothing. It's added after the render instead, and `AGENTS.md` now warns against the general case, since it applies to anything anyone tries to put in these pages' `<head>`.

## Verified on a clean render

- **6,140,472 bytes**, **17** data-URI blocks totalling **1,771,483** — both at the pre-change baseline
- canonical link present exactly once, with a real href
- 1,590 search hrefs rewritten, **zero non-`href` differences** in `search.json` (checked field-by-field); `objectID` deliberately untouched, it's fuse's index key not a navigation target
- all 1,473 anchors still present
- `make check` green, same 9 known gaps; 6 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)