### PR TITLE
Close gap C1 — the 819 categorical values resolve

### DIFF
--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -24,7 +24,7 @@ for the downstream ripple when the vocabulary itself changes.
 
 | # | Commitment | Source | Checked by |
 |---|---|---|---|
-| C1 | Every trait concept, **allowable categorical trait value**, trait grouping and glossary term has a unique, stable URI that resolves to that term's content. | p.8 | `test-commitments.R` — uniqueness and form of all 1,473. `scripts/build_site.R` — every one has an anchor in the rendered page. `check_redirects.sh` — one per class resolves live. Resolution for the 819 is gap C1. |
+| C1 | Every trait concept, **allowable categorical trait value**, trait grouping and glossary term has a unique, stable URI that resolves to that term's content. | p.8 | `test-commitments.R` — uniqueness and form of all 1,473. `scripts/build_site.R` — every one has an anchor in the rendered page. `check_redirects.sh` — one per class resolves live, plus the `+` slug. **Met in full since the stage 5 w3id rule change** (2026-07); the 819 categorical values used to land at the top of the page. |
 | C2 | `data/APD_namespace_declaration.csv` is the namespace declaration used when compiling the RDF representation. | p.8 | `test-namespaces.R` — **true since 98ceeb4**; the file is now the only source. |
 | C3 | `APD.ttl` passes SKOS validation: relationships consistent, all URIs unique, all concepts labelled. | p.13 | `test-commitments.R` — every one of the 1,475 APD subjects carries a `skos:prefLabel`. Datatype problems remain: gap C5. |
 | C4 | The data are available under **CC BY 4.0**. | p.12 | `test-commitments.R` — `LICENSE` exists and says CC BY 4.0. |
@@ -65,20 +65,6 @@ problem id, with the reason it is still open. `make check` reports them every ru
 change. Anything *not* on that register fails the build, so new breakage cannot hide behind the
 existing debt. **Fixing a gap means deleting its register entry**, and a test fails if an entry
 outlives the problem it describes.
-
-- **C1 — broken for all 819 categorical trait values.** The w3id rule is `^traits/trait_(.+)$`.
-  Categorical URIs look like `https://w3id.org/APD/traits/plant_growth_form_tree`, do not match, and
-  fall through to the catch-all — landing at the top of `index.html` with no fragment. Trait concepts,
-  trait groups and glossary terms are fine. The anchors themselves all exist — all 1,473 of them,
-  checked at render — so widening the rule is the whole fix, and `scripts/check_redirects.sh` carries
-  this as an expected failure that goes red the moment it starts passing.
-
-  ```
-  w3id.org/APD/traits/trait_0000012           -> index.html#trait_0000012   OK
-  w3id.org/APD/traits/trait_group_0000008     -> index.html#trait_group_…   OK
-  w3id.org/APD/glossary/glossary_0000001      -> index.html#glossary_…      OK
-  w3id.org/APD/traits/plant_growth_form_tree  -> index.html                 BROKEN
-  ```
 
 - **C3 — partly checked.** Every APD concept now provably carries a label, and URI uniqueness is
   tested. What a real SKOS validator would still reject are the datatype problems below.

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,20 @@ format:
      `apd_released_versions()` matches only that form, so an "Unreleased" section
      is invisible to the version checks and to "Previous version" on the site. -->
 
+**All 819 allowable categorical trait values now resolve to their own definition.**
+Their persistent identifiers look like
+<https://w3id.org/APD/traits/plant_growth_form_tree>, and the redirect rule behind
+`w3id.org/APD` matched only identifiers beginning `trait_`. So every categorical
+value fell through to a catch-all and landed at the top of the dictionary rather
+than at the term you asked for — while trait concepts, trait groupings and
+glossary terms resolved correctly, which is why it went unnoticed. Wenk et al.
+2024 (p.8) names allowable categorical values as one of the four classes
+guaranteed a resolvable URI, so this was a published commitment unmet for 819 of
+them.
+
+**No identifier changed** — only where they point. Anything you have already cited
+still resolves, and now to the right place.
+
 **Allowable categorical values now sit under their trait in the contents.** In
 section 4 of the dictionary, each of the 819 allowable values was headed at the
 same level as the 115 traits that own them, so the contents listed all 934 as one

--- a/plans/build-workflow-overhaul.md
+++ b/plans/build-workflow-overhaul.md
@@ -8,8 +8,10 @@
 > N-Triples statements. The release carries its build artefacts as assets, which no previous APD release
 > did. Verified against the live service, not asserted.
 >
-> **Stage 5 is ready to open and its gate has passed** — see that section for the exact rule and the
-> evidence. Stage 6 (CI) went first, since it is what makes the deploy repeatable.
+> **Stage 5 is merged and live** (verified against w3id.org, 2026-07-29). Every `traits/` slug now
+> resolves to its own anchor — the 819 categorical values included, and the `+` slug with them. Gap C1
+> is closed, its register entry is deleted, and `check_redirects.sh` asserts the categorical and `+`
+> cases so it stays closed. Stage 6 (CI) went first, since it is what makes the deploy repeatable.
 >
 > **Stage 6's first PR is merged and its gate has passed** (2026-07-28). All four workflows run, the
 > site deploys from `master` via Actions, and `verify` is clean against the live service. It found and
@@ -17,10 +19,11 @@
 > that had never been declared. `master` is now **release-only**: it moves at a release, not per PR,
 > which was only possible once Pages stopped being served from `master:/docs`. `docs/` is untracked.
 >
-> **Stages 0–4, 6 and 7 are done.** `CONTRIBUTING.md` and `RELEASING.md` are written; writing the
+> **Every stage is now done.** `CONTRIBUTING.md` and `RELEASING.md` are written; writing the
 > release checklist found that the ARDC RVA deposit is two releases behind and that
-> `austraits.build` still pins APD 2.1.0. **Stage 5 — the one-line w3id rule change that fixes 819
-> published identifiers — is the only stage left**, and it is a PR to a third-party repository.
+> `austraits.build` still pins APD 2.1.0. Both are follow-ups this plan does not cover. Stage 5 still
+> owes a `NEWS.md` entry — the fix is live but unrecorded, and it belongs in the next release's notes
+> rather than under the already-published 2.1.1 heading.
 >
 > **No release needed to deploy this.** The dictionary is unchanged — verified against `master`, not
 > asserted: 27,523 statements both sides, differing only in 31 `min`/`max` literals reformatted from
@@ -601,7 +604,15 @@ first.
 
 ### Stage 5 — w3id redirect change
 
-**Ready to open. The gate has passed.** A target-only change; no URI changes. One line of
+**Merged upstream and verified live on 2026-07-29.** `traits/plant_growth_form_tree`,
+`traits/seed_germination_treatment_heat+smoke`, `traits/trait_0000012`,
+`traits/trait_group_0000008` and `glossary/glossary_40004` all resolve to their own anchor. The
+prediction below held: nothing else moved, and the gate's claim that all 1,473 anchors exist is what
+made that safe. What is left is a `NEWS.md` entry, and a separate proposal — not part of this stage —
+to stop w3id serving the dictionary page in response to a request that names a file (`/APD/APD_traits.csv`
+and `/APD/release/2.1.1/APD_traits.csv` both return HTTP 200 with HTML).
+
+A target-only change; no URI changes. One line of
 [`perma-id/w3id.org/APD/.htaccess`](https://github.com/perma-id/w3id.org/blob/master/APD/.htaccess),
 line 57:
 
@@ -643,6 +654,55 @@ traits/plant_growth_form_tree  ->  200 index.html#plant_growth_form_tree       #
 
 It closes gap C1, a published commitment currently unmet for 819 identifiers, and deserves a `NEWS.md`
 entry.
+
+### Stage 5b — w3id file pass-through (proposed, not opened)
+
+**The problem.** w3id.org negotiates on `Accept` and resolves identifiers; a request that *names a
+file* does neither, so it reaches the catch-all and gets the dictionary document with a `200`. Both of
+these serve 6 MB of HTML to anything that pipes the result into a CSV parser:
+
+```
+https://w3id.org/APD/APD_traits.csv                 -> 200, index.html
+https://w3id.org/APD/release/2.1.1/APD_traits.csv   -> 200, index.html
+```
+
+The RDF serialisations are reachable by negotiation, so this bites the two CSVs hardest — and they are
+the artefacts `using_the_APD.qmd` tells readers to download. The document currently has to carry a
+warning callout explaining that the obvious URL lies.
+
+**The rule.** Two lines, inserted *before* the HTML section — ordering is the whole subtlety, since
+`^release/(\d+)\.(\d+)\.(\d+)(.+)?$` matches `release/2.1.1/APD_traits.csv` and would swallow it:
+
+```apache
+RewriteRule ^release/(\d+)\.(\d+)\.(\d+)/([\w.-]+\.(csv|ttl|nt|nq|json))$ https://traitecoevo.github.io/APD/release/$1.$2.$3/$4 [R=303,L]
+
+RewriteRule ^([\w.-]+\.(csv|ttl|nt|nq|json))$ https://traitecoevo.github.io/APD/$1 [R=303,L]
+```
+
+**Match basenames generically, do not enumerate them.** The snapshots do not carry the same file set:
+`release/1.0.0/` has `APD.csv` and no `APD_traits.csv`, while `release/2.1.1/` adds
+`APD_trait_hierarchy.csv` and `APD_traits_input.csv`. A rule listing today's filenames silently stops
+covering tomorrow's. Let the site 404 what it does not have — a 404 is a *correct* answer here, and the
+failure this fixes is that the wrong answer currently arrives as a 200.
+
+**`html` is deliberately absent from the extension list.** `release/X.Y.Z/index.html` must keep falling
+through to the rule below it, which sends it to the directory form so the document keeps one URL.
+
+**Simulated against the whole chain before proposing it.** Only file-named paths change: the six real
+ones resolve to their file, `nonexistent.csv` becomes a 404 instead of a 200 with HTML, and everything
+else is byte-identical — every negotiated path latest and versioned, `release/2.1.1/` in all three
+spellings, every `traits/` slug including `trait_group_` and `heat+smoke`, both collection URIs, and
+the base URI.
+
+**Consequences to settle before opening the PR.**
+
+- COMMITMENTS.md C12 names the `traitecoevo.github.io` paths as the published URLs for these files.
+  This does not move them, it adds an alias — but C12 should then say whether the w3id form is
+  promised too, or is an undocumented convenience.
+- `check_redirects.sh` already has a *Published data files* section that sniffs for `<!DOCTYPE` against
+  `$SITE`. Extend that same loop over `https://w3id.org/APD/` once the rule is live; the harness exists.
+- `using_the_APD.qmd`'s warning callout gets rewritten, and the CSV download URLs in it can move to the
+  persistent form.
 
 ### Stage 6 — CI and deployment
 

--- a/scripts/check_redirects.sh
+++ b/scripts/check_redirects.sh
@@ -107,24 +107,21 @@ done
 
 section "Identifier resolution -- one per entity class"
 
+# The categorical value is the one that used to fail: the rule matched only
+# `trait_`, so all 819 fell through to the catch-all and landed at the top of the
+# page. The stage 5 rule change widened it to `^traits/([^/]+)/?$`, and this line
+# is what proves it stayed fixed. `heat+smoke` is here because `+` is the one slug
+# character a narrower character class would have missed.
 for spec in "traits/trait_0000012:trait_0000012" \
             "traits/trait_group_0000008:trait_group_0000008" \
+            "traits/plant_growth_form_tree:plant_growth_form_tree" \
+            "traits/seed_germination_treatment_heat+smoke:seed_germination_treatment_heat+smoke" \
             "glossary/glossary_40004:glossary_40004"; do
   path="${spec%%:*}"
   anchor="${spec##*:}"
   expect "$path" "$(resolve "https://w3id.org/APD/$path")" \
     "200 index.html#$anchor"
 done
-
-# Gap C1. The w3id rule is `^traits/trait_(.+)$`; categorical value slugs do not
-# start with `trait_`, so all 819 fall through to the catch-all and land at the
-# top of the page with no fragment. Stage 5 of plans/build-workflow-overhaul.md
-# widens the rule to `^traits/([^/]+)/?$`, at which point this line goes green
-# and the entry below has to go.
-expect "traits/plant_growth_form_tree" \
-  "$(resolve "https://w3id.org/APD/traits/plant_growth_form_tree")" \
-  "200 index.html#plant_growth_form_tree" \
-  "gap C1, fixed by the stage 5 w3id rule change"
 
 
 # --- versioned permalinks ----------------------------------------------------


### PR DESCRIPTION
The stage 5 w3id rule change merged upstream ([perma-id/w3id.org#6444](https://github.com/perma-id/w3id.org/pull/6444)) and is live. Every `traits/` slug now resolves to its own anchor — the 819 allowable categorical values included, and the `+` slug that a narrower character class would have missed.

Verified against `w3id.org`, not asserted. **`scripts/check_redirects.sh` reports "All checks passed" for the first time** — no gaps, no failures.

## So the register entry goes

Per the repo's own rule — *fixing a gap means deleting its entry*, and a test fails if an entry outlives its problem:

| | |
|---|---|
| `COMMITMENTS.md` | C1 marked met in full; its known-gaps bullet removed |
| `check_redirects.sh` | `plant_growth_form_tree` and `heat+smoke` are now ordinary expectations, not a recorded expected failure |
| `plans/` | stage 5 recorded as merged and verified, plus a proposed stage 5b |

## The NEWS entry that was missing

The working tree had the register cleanup but no changelog entry, and the plan explicitly called for one. **819 published identifiers started resolving to their definitions** — that's the user-visible half, and it would have shipped silently. Added, with the point that matters most to anyone who has cited one: *no identifier changed, only where it points.*

## One thing worth knowing about how this was assembled

`COMMITMENTS.md` was **hand-merged, not copied.** These edits were made against a version that predates #58, which rewrote the known-gaps section on `develop` — the `DD/MM/YYYY` date analysis, the restructured input-data entries, the #59 references. A wholesale copy would have silently reverted all of it. Only the two C1 edits are applied here; I verified #58's changes are still present.

`make check` green, same 9 known gaps in the data register (C1 was never one of them — it lived in prose and in the redirect script, not in `APD_KNOWN_GAPS`).

## Heads-up on ordering

[w3id#6454](https://github.com/perma-id/w3id.org/pull/6454) is still open. When it merges, `check_redirects.sh` needs its expectations flipped from `index.html#<slug>` to `#<slug>` and `release/<v>/index.html` to `release/<v>/` — four sites. Not done here because it would make the script wrong against the *current* live service.

Split from a single working tree into two PRs; the other is #61.