### PR TITLE
Expect the directory URL from the w3id HTML redirects (blocked on w3id#6454)

### DIFF
--- a/scripts/check_redirects.sh
+++ b/scripts/check_redirects.sh
@@ -34,12 +34,19 @@ gaps=0
 # is a community-run service and this runs unattended on a schedule.
 CURL=(curl -sS -o /dev/null -L --retry 3 --retry-delay 2 --max-time 30)
 
+# The HTML targets are the *directory* form -- /APD/#<slug>, not
+# /APD/index.html#<slug>. Both serve the same document, so naming the second gave
+# one page two URLs: two browser cache entries, and a search result clicked from
+# /APD/ reloaded 6 MB instead of jumping. See perma-id/w3id.org#6454 and #60.
+#
+# resolve() strips the site root but keeps the leading '/', so the bare document
+# reads as "/" rather than an empty string.
 resolve() {  # url [accept] -> "<status> <final-path>"
   local url="$1" accept="${2:-}" args=("${CURL[@]}")
   [[ -n "$accept" ]] && args+=(-H "Accept: $accept")
   printf '%s %s' \
     "$("${args[@]}" -w '%{http_code}' "$url")" \
-    "$("${args[@]}" -w '%{url_effective}' "$url" | sed "s|$SITE/||")"
+    "$("${args[@]}" -w '%{url_effective}' "$url" | sed "s|$SITE||")"
 }
 
 expect() {  # label actual expected [known-gap-explanation]
@@ -78,8 +85,8 @@ section() { printf '\n%s\n' "$1"; }
 
 section "Content negotiation"
 
-for spec in "text/turtle:APD.ttl" "application/n-triples:APD.nt" \
-            "application/n-quads:APD.nq" "application/ld+json:APD.json"; do
+for spec in "text/turtle:/APD.ttl" "application/n-triples:/APD.nt" \
+            "application/n-quads:/APD.nq" "application/ld+json:/APD.json"; do
   accept="${spec%%:*}"
   want="${spec##*:}"
   for path in "" /traits /glossary; do
@@ -88,9 +95,10 @@ for spec in "text/turtle:APD.ttl" "application/n-triples:APD.nt" \
   done
 done
 
-# The collection URIs land on their section of the document, not its top.
-for spec in ":index.html" "/traits:index.html#trait-concepts" \
-            "/glossary:index.html#glossary"; do
+# The document itself, and the two collection URIs, which land on their section
+# of it rather than its top.
+for spec in ":/" "/traits:/#trait-concepts" \
+            "/glossary:/#glossary"; do
   path="${spec%%:*}"
   want="${spec#*:}"
   expect "text/html APD$path" \
@@ -120,7 +128,7 @@ for spec in "traits/trait_0000012:trait_0000012" \
   path="${spec%%:*}"
   anchor="${spec##*:}"
   expect "$path" "$(resolve "https://w3id.org/APD/$path")" \
-    "200 index.html#$anchor"
+    "200 /#$anchor"
 done
 
 
@@ -132,13 +140,17 @@ done
 # site, so a deploy that stops carrying release/ silently 404s all of them. That
 # is the failure the stage 6 gate exists to catch.
 
+# Requested in the legacy `index.html` form on purpose: that is what index.qmd
+# published as "This version" and what the Zenodo deposits cite, so it is the form
+# most likely to be in someone's bibliography. It has to keep resolving, and it
+# should land on the canonical directory URL.
 section "Versioned permalinks -- every snapshot in release/"
 
 for dir in "$ROOT"/release/*/; do
   version="$(basename "$dir")"
   expect "release/$version/index.html" \
     "$(resolve "https://w3id.org/APD/release/$version/index.html")" \
-    "200 release/$version/index.html"
+    "200 /release/$version/"
 done
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — must not merge before [perma-id/w3id.org#6454](https://github.com/perma-id/w3id.org/pull/6454).** It is correct only *after* that lands, and wrong until then. Merging early turns the weekly `redirects.yml` cron red.

Pairs with #6454, which drops `index.html` from the six HTML-serving rules so `/APD/` is the only URL for the dictionary. This updates `check_redirects.sh` to expect that.

```
text/html on APD, APD/traits, APD/glossary   ->  /   /#trait-concepts   /#glossary
every traits/ and glossary/ identifier       ->  /#<slug>
release/<version>/index.html                 ->  /release/<version>/
```

The RDF content-negotiation targets and the published data files are untouched — #6454 only changed where HTML is served from.

## Why it's already verified

Run against the live service **today**, which still has the old targets:

```
  ok:   20
  FAIL: 13
  gap:   0
```

Every one of the 13 differs *only* by the `index.html` segment:

```
[ FAIL ] traits/plant_growth_form_tree     200 /index.html#plant_growth_form_tree
         want                              200 /#plant_growth_form_tree
[ FAIL ] release/2.1.1/index.html          200 /release/2.1.1/index.html
         want                              200 /release/2.1.1/
```

…and the 20 that pass are exactly the RDF and data-file lines that #6454 doesn't affect. So this goes green the moment #6454 lands, and the failure set is proof rather than assertion.

## Two deliberate details

**`resolve()` now keeps the leading `/`** when stripping the site root, so the bare document reads as `/` rather than an empty string. Without it, the expectation would be the literal `"200 "` with an invisible trailing space — fragile to edit and impossible to review.

**Versioned permalinks are still requested in the legacy `index.html` form.** That's what `index.qmd` published as "This version" and what the Zenodo deposits cite, so it's the form most likely to sit in someone's bibliography. It has to keep resolving, and it should land on the canonical directory URL — this asserts both in one request.

## After merging: fast-forward `master`

`develop` is ahead of `master` by several commits and **none of it is live**, because `master` is release-only now. Specifically pending: the canonical-URL and search-index fix (#60), the C1 closure (#62), the untracked `docs/` (#55), the docs (#56), and the allowable-value heading nesting — which `NEWS.md` already has staged under `## Unreleased`.

Two ways to land it, and it's a real choice:

- **Cut 2.1.2.** The `Unreleased` section documents a published-output change (the contents nesting), and `RELEASING.md` says to rename that heading rather than add another. This is the option the changelog is already set up for.
- **Fast-forward `master` without a bump**, as a one-off — which is what the release-only rule exists to avoid.

I'd cut the release: it's the only way the ARDC RVA refresh and the `austraits.build` pin bump (#852) get picked up coherently, and both are already stale.

Note `deploy.yml`'s `verify` job runs `check_redirects.sh` from `master`, so until `master` moves it will still be running the *old* expectations — which is fine, since it's checking a site that still has the old targets.