### PR TITLE
Correct the release sequence, and record that Zenodo is manual

### DIFF
--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -112,8 +112,24 @@ outlives the problem it describes.
   > true: there are no ENVO entries in `published_classes.csv`, which already carries 95 colon-style
   > identifiers against 657 underscore-style; and the units `identifier` column reaches no output.
 
-- **C8 — stale.** ARDC RVA (`vocabs.ardc.edu.au/viewById/649`) serves **2.0.1**; this repo is at 2.1.0.
-  Refreshing the deposit belongs on the release checklist.
+- **C8 — check it by eye.** ARDC RVA (`vocabs.ardc.edu.au/viewById/649`) has historically lagged; it
+  was two releases behind at the 2026-07 audit. The version is not reliably machine-readable — the
+  registry API does not expose it and the page carries more than one version-shaped string — so this
+  cannot be a CI check. Refreshing the deposit is on the release checklist.
+
+- **C9 — unmet for 2.1.1 and 2.1.2.** Zenodo's latest deposit under concept DOI
+  `10.5281/zenodo.8040789` is **2.1.0**; the concept DOI resolved to that record on 2026-07-29 with the
+  repo at 2.1.2. Two releases are unarchived.
+
+  The cause is a wrong assumption, now corrected in `RELEASING.md`: **Zenodo deposits for the APD are
+  manual uploads, not the GitHub integration.** Cutting a GitHub Release deposits nothing. The evidence
+  is in the deposited file sets — they are curated (they include `APD_triples.csv` and
+  `using_the_APD.html`, and omit `APD_trait_hierarchy.csv` and `APD_traits_input.csv`), so they cannot
+  be source tarballs.
+
+  Switching to the GitHub integration was considered and rejected: it archives the repository tarball
+  rather than the published outputs, and it mints its **own** concept DOI, which would fork the citation
+  lineage away from `10.5281/zenodo.8040789` — the DOI in `README.md`, `index.qmd` and the paper.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,24 +55,68 @@ a PR to `develop`, let CI pass, merge.
 
 ## 2. Publish
 
+Do these in order. Each step depends on the one before, and 2.1.2 went wrong in three places by not
+respecting that — the notes at the end of this section record how.
+
+**a. Merge the release PR, then update your local refs.**
+
 ```bash
-git checkout master && git merge --ff-only develop && git push
+gh pr checks <n>                       # green before merging
+# merge the release PR on GitHub
+git checkout develop && git pull       # <- do not skip
 ```
 
-If that refuses, the branches have diverged and the reason needs finding, not forcing.
+> ⚠️ **`git merge --ff-only develop` merges your *local* `develop` ref, not the remote one.** If you
+> merged the release PR in the browser and did not pull, the fast-forward silently publishes the commit
+> *before* the release. It succeeds, so nothing warns you. This is what happened cutting 2.1.2:
+> `master` landed on the previous commit, the site deployed without `release/2.1.2/`, and the tag was
+> created on a commit whose `DESCRIPTION` still said 2.1.1.
+
+**b. Fast-forward `master` and let it deploy.**
+
+```bash
+git checkout master && git merge --ff-only develop && git push
+git log --oneline -1                   # confirm this is the release commit
+```
+
+If the merge refuses, the branches have diverged and the reason needs finding, not forcing.
 
 The push triggers [`deploy.yml`](.github/workflows/deploy.yml), which validates, renders, copies
-`release/` into the site, deploys to Pages, and then runs `scripts/check_redirects.sh` against the
-live service. **Wait for the `verify` job.** A green deploy and a resolving site are different claims;
-`verify` is the one that checks the second.
+`release/` into the site, deploys to Pages, then runs `scripts/check_redirects.sh` against the live
+service. **Wait for the `verify` job.** A green deploy and a resolving site are different claims;
+`verify` checks the second.
+
+> Deploys queue rather than cancel (concurrency group `pages`, `cancel-in-progress: false`). So a
+> mistaken push followed by a corrected one means two runs, serialised, ~8–10 minutes each — and the
+> permalink 404s until the second finishes.
+
+**c. Confirm the release is actually live before tagging.**
+
+```bash
+curl -sI -o /dev/null -w '%{http_code}\n' \
+  https://traitecoevo.github.io/APD/release/<X.Y.Z>/index.html   # want 200
+```
+
+Tag only once this returns 200 and `master` is the release commit. A tag is what Zenodo and citations
+point at; moving one afterwards means deleting a published ref.
 
 ```bash
 git tag v<X.Y.Z> && git push --tags
-gh release create v<X.Y.Z> --title "APD v<X.Y.Z>" --notes-file <notes> release/<X.Y.Z>/*
 ```
 
-Attach the whole snapshot directory — nine files. Releases before 2.1.1 carried **no assets at all**,
-which meant Zenodo archived only a source tarball of the tag.
+**d. Cut the GitHub Release.**
+
+Extract this version's section from `NEWS.md` into a scratch file first — the flag takes a real path,
+and `--notes-file <notes>` with angle brackets is shell input redirection, not a placeholder your shell
+will prompt about:
+
+```bash
+gh release create v<X.Y.Z> --title "APD v<X.Y.Z>" \
+  --notes-file /tmp/apd-notes.md release/<X.Y.Z>/*
+gh release view v<X.Y.Z> --json assets --jq '.assets | length'   # want 9
+```
+
+Attach the whole snapshot directory — nine files. Releases before 2.1.1 carried **no assets at all**.
 
 ## 3. The three things outside this repo
 
@@ -80,16 +124,51 @@ This is the part that gets missed.
 
 ### Zenodo — commitment C9
 
-Concept DOI [`10.5281/zenodo.8040789`](https://doi.org/10.5281/zenodo.8040789). The GitHub integration
-deposits on release; confirm the new version appears and carries the assets, not just the tarball.
+Concept DOI [`10.5281/zenodo.8040789`](https://doi.org/10.5281/zenodo.8040789).
+
+> ⚠️ **This is a manual upload. Nothing deposits automatically.** An earlier version of this document
+> said the GitHub integration handles it. It does not: the deposited file sets are hand-curated and do
+> not match a source tarball, and cutting a GitHub Release deposits nothing. Verified 2026-07-29 —
+> the concept DOI resolved to **2.1.0** while the repo was at 2.1.2, so **neither 2.1.1 nor 2.1.2 was
+> ever archived.** C9 is currently unmet for both.
+
+On zenodo.org, open the concept DOI, choose **New version**, and upload the files. The set deposited
+for 2.1.0 was **not** the same as `release/<version>/`:
+
+| File | in `release/<v>/` | on Zenodo |
+|---|:-:|:-:|
+| `APD.ttl`, `APD.nt`, `APD.nq`, `APD.json` | ✅ | ✅ |
+| `APD_traits.csv`, `APD_categorical_values.csv` | ✅ | ✅ |
+| `index.html` | ✅ | ✅ |
+| `APD_triples.csv` | — | ✅ |
+| `using_the_APD.html` | — | ✅ |
+| `APD_trait_hierarchy.csv`, `APD_traits_input.csv` | ✅ | — |
+
+Decide deliberately which set you are depositing rather than inheriting this by accident. `APD_triples.csv`
+and `using_the_APD.html` are both in `docs/` after `make site`; the other two are in the snapshot.
+
+Then set the version field to `<X.Y.Z>` — Zenodo does not infer it — and check the record lists the
+version you expect:
+
+```bash
+curl -s -o /dev/null -L -w '%{url_effective}\n' https://doi.org/10.5281/zenodo.8040789
+curl -s "https://zenodo.org/api/records?q=conceptdoi:%2210.5281/zenodo.8040789%22&all_versions=true&sort=-version" \
+  | python3 -c "import json,sys; [print(h['metadata'].get('version'), h['doi']) for h in json.load(sys.stdin)['hits']['hits']]"
+```
 
 ### ARDC Research Vocabularies Australia — commitment C8
 
 <https://vocabs.ardc.edu.au/viewById/649> must serve the new `APD.ttl`. Figure 4 of the paper promises
 a copy is "archived and discoverable" there.
 
-> **Currently stale: RVA serves 2.0.1 against a repo at 2.1.1.** Two releases behind. Nothing
-> automated catches this, which is why it is on the checklist rather than in CI.
+**Check the version on the record by eye.** It is not reliably machine-readable: the registry API does
+not expose it, and the public page carries more than one version-shaped string (2026-07-29 it showed
+both `2.0.18` and `2.1.1`, only one of which is the vocabulary version). So this is a look-and-confirm
+step, not something to script.
+
+> Deliberately left manual, along with Zenodo. Both are external services with no reliable API for
+> "what version is published", so a scheduled check would either need scraping or would give false
+> confidence. Revisit if ARDC exposes the version properly.
 
 ### The downstream pin
 
@@ -103,7 +182,12 @@ apd_version <- "2.1.0"    # line 16
 Bump it, re-run the script to regenerate `config/traits.yml`, and rebuild. Trait validation failures
 there are the point — they are records using something this release changed.
 
-> **Currently stale: it pins 2.1.0 against an APD at 2.1.1.**
+**The script reads the release over HTTP**, so this step cannot run until the deploy in step 2b has
+finished and `https://traitecoevo.github.io/APD/release/<X.Y.Z>/APD_traits.csv` returns 200. Check
+before running it, or you will pin a version that 404s.
+
+> The pin was two releases behind when 2.1.2 was cut, and nothing surfaced it from inside this repo —
+> which is why it is on this list. See traitecoevo/austraits.build#852.
 
 Sibling databases that pin the APD (`AusFizz`, `ausinvertraits.build`) need the same treatment. For a
 breaking change, follow the
@@ -129,18 +213,38 @@ by" column, the known-gaps list, and C8's staleness note.
 
 ## Checklist
 
+The order is not cosmetic — four of these gate the ones after them, marked `←`.
+
 ```
+prepare
 [ ] DESCRIPTION bumped
-[ ] NEWS.md section added
+[ ] NEWS.md `## Unreleased` renamed to `## APD Version <X.Y.Z>`
 [ ] make release            (refuses if either of the above is missing)
 [ ] PR to develop, CI green, merged
+
+publish
+[ ] git checkout develop && git pull                   ← or the next step
+                                                         publishes the wrong commit
 [ ] master fast-forwarded and pushed
-[ ] deploy.yml verify job green
+[ ] `git log --oneline -1` on master IS the release commit
+[ ] deploy.yml verify job green                        ← two deploys queue if you
+                                                         pushed a wrong one first
+[ ] release/<X.Y.Z>/index.html returns 200 live        ← before tagging
 [ ] tag pushed
-[ ] GitHub Release created with all nine assets
-[ ] Zenodo deposit confirmed                              (C9)
-[ ] ARDC RVA deposit refreshed                            (C8)
-[ ] austraits.build apd_version bumped and rebuilt
+[ ] notes extracted from NEWS.md into a real file      ← --notes-file needs a path
+[ ] GitHub Release created, `gh release view` shows 9 assets
+
+outside this repo — all manual, none automatic
+[ ] Zenodo: New version under the concept DOI, files uploaded,
+    version field set                                      (C9)
+[ ] ARDC RVA refreshed, version on the record checked by eye (C8)
+[ ] release/<X.Y.Z>/APD_traits.csv returns 200 live    ← before the next step
+[ ] austraits.build apd_version bumped, script re-run, rebuilt
 [ ] sibling databases rebuilt, if the change is breaking
 [ ] COMMITMENTS.md re-read and updated
 ```
+
+**What went wrong cutting 2.1.2**, all three from ignoring the order above: a stale local `develop`
+put `master` and the tag on the pre-release commit; the tag then had to be deleted and re-pushed;
+and `--notes-file <notes>` was taken literally by the shell. None of it reached Zenodo, because the
+Release never got created — which is the only reason it was recoverable.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -132,6 +132,10 @@ Concept DOI [`10.5281/zenodo.8040789`](https://doi.org/10.5281/zenodo.8040789).
 > the concept DOI resolved to **2.1.0** while the repo was at 2.1.2, so **neither 2.1.1 nor 2.1.2 was
 > ever archived.** C9 is currently unmet for both.
 
+**Elizabeth Wenk owns the Zenodo record** — the deposit has to be made from her account, so this step
+is a hand-off rather than something the person cutting the release can finish. Give her the version
+number, the files, and the description block below.
+
 On zenodo.org, open the concept DOI, choose **New version**, and upload the files. The set deposited
 for 2.1.0 was **not** the same as `release/<version>/`:
 
@@ -210,6 +214,76 @@ Then re-read [`COMMITMENTS.md`](COMMITMENTS.md) and update anything this release
 by" column, the known-gaps list, and C8's staleness note.
 
 ---
+
+## The Zenodo record description
+
+Paste this into the **Description** field, replacing `X.Y.Z`. Zenodo accepts a small HTML subset, so
+this uses only `<p>`, `<ul>`, `<li>`, `<a>`, `<strong>`, `<code>`. Keep it with the repo so each release
+reuses it rather than re-deriving it.
+
+The version deposited before this was written carried the site abstract verbatim, which left three
+things wrong: two typos it inherited (`trait focused`, `traits describe here`), links that were plain
+text rather than anchors, and — the real gap — **no explanation of the nine files**, so a visitor saw
+`APD.ttl`, `APD.nt`, `APD.nq`, `APD.json`, two CSVs, `APD_triples.csv` and two HTML files with nothing
+saying which to take.
+
+```html
+<p>The <strong>AusTraits Plant Dictionary (APD)</strong> is a formal vocabulary defining more than 500
+plant trait concepts, covering plant morphology, nutrient concentrations, physiology, life history and
+fire response. Every trait carries a definition, expected units, an allowed range or an enumerated set
+of allowed values, keywords, references, reviewers, and mappings to equivalent traits in other trait
+databases and ontologies. The definitions support the
+<a href="https://doi.org/10.5281/zenodo.3568417">AusTraits</a> plant trait database, and are intended
+for reuse well beyond it.</p>
+
+<p><strong>Cite the APD by its persistent identifier</strong>,
+<a href="https://w3id.org/APD">https://w3id.org/APD</a>, together with the version you used. Every
+trait concept, trait grouping, allowable categorical value and glossary term has its own resolvable
+identifier under that namespace — for example
+<a href="https://w3id.org/APD/traits/trait_0000012">https://w3id.org/APD/traits/trait_0000012</a>.
+Content negotiation on those identifiers returns any of the RDF serialisations below.</p>
+
+<p><strong>This deposit is version X.Y.Z.</strong> The files are:</p>
+<ul>
+<li><code>index.html</code> — the whole dictionary as one human-readable document, the same page served
+at <a href="https://w3id.org/APD">w3id.org/APD</a>.</li>
+<li><code>APD.ttl</code> — RDF in Turtle. The most compact serialisation and the one to start from for
+most RDF tooling.</li>
+<li><code>APD.nt</code> / <code>APD.nq</code> — the same graph as N-Triples and N-Quads: one statement
+per line, streamable and parseable without an RDF library.</li>
+<li><code>APD.json</code> — the same graph as JSON-LD, for JavaScript and Python tooling.</li>
+<li><code>APD_traits.csv</code> — one row per trait concept with all its metadata. The flat table most
+analyses want.</li>
+<li><code>APD_categorical_values.csv</code> — one row per allowed value of a categorical trait.</li>
+<li><code>APD_triples.csv</code> — the intermediate triple table the RDF is built from, with
+human-readable labels resolved.</li>
+<li><code>using_the_APD.html</code> — worked examples: fetching the serialisations, querying the graph
+with SPARQL, filtering the tables, and labelling your own data with APD identifiers.</li>
+</ul>
+
+<p>The dictionary is also browsable, searchable and queryable at
+<a href="https://vocabs.ardc.edu.au/viewById/649">Research Vocabularies Australia</a>. It is built from
+source at <a href="https://github.com/traitecoevo/APD">github.com/traitecoevo/APD</a>, where this
+version is tagged <code>vX.Y.Z</code>; the change log is at
+<a href="https://traitecoevo.github.io/APD/news.html">traitecoevo.github.io/APD/news.html</a>.</p>
+
+<p>Definitions and metadata are released under
+<a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+```
+
+### Metadata to fix while you are in there
+
+- **`isPublishedIn` points at the preprint.** The 2.1.0 record relates to
+  `10.1101/2023.06.16.545047` (bioRxiv). The paper has been out since 2024 — it should be
+  **`10.1038/s41597-024-03368-z`** (*Sci Data* **11**:537). Keep the preprint if you like, but the
+  published article is what should carry `isPublishedIn`.
+- **Keywords are three words** — `plant`, `trait`, `biodiversity`. Worth adding `plant functional
+  traits`, `vocabulary`, `ontology`, `SKOS`, `RDF`, `AusTraits`, `Australia`, so the record is
+  findable as a vocabulary rather than only as a dataset.
+- **Set the version field** to `X.Y.Z`. Zenodo does not infer it from the files or the title.
+
+The rest of the metadata on 2.1.0 is right and should carry over: `Dataset`, CC BY 4.0, six creators,
+and the `isIdenticalTo` relations to `w3id.org/APD` and the RVA record.
 
 ## Checklist
 


### PR DESCRIPTION
Cutting 2.1.2 went wrong in three places, all traceable to this document being vague about order or wrong about a mechanism. Rewritten so the next release can't repeat them.

## The three failures

**1. `git merge --ff-only develop` merges your *local* `develop`.** Merge the release PR in the browser, forget to pull, and the fast-forward silently puts `master` on the commit *before* the release — and it **succeeds**, so nothing warns you. That's what put `master` and the `v2.1.2` tag on a commit whose `DESCRIPTION` still said 2.1.1; the tag had to be deleted and re-pushed.

Step 2a is now an explicit `git pull` with the trap spelled out, plus a "confirm `master` is the release commit" check after it.

**2. Tagging before the release was live.** Now gated on `release/<X.Y.Z>/index.html` returning 200, because a tag is what Zenodo and citations point at — moving one means deleting a published ref. Also records that deploys **queue rather than cancel**, so a mistaken push means two serialised ~9-minute runs and a permalink that 404s until the second lands.

**3. `--notes-file <notes>`** was a placeholder, but `<` is shell input redirection — zsh tried to open a file called `notes`. Now shows a real path and says to extract the section from `NEWS.md` first.

## Zenodo does not deposit automatically

This document claimed the GitHub integration handles it. **It does not.** Verified 2026-07-29: the concept DOI resolved to **2.1.0** with the repo at 2.1.2, so **neither 2.1.1 nor 2.1.2 was ever archived**. C9 is unmet for both.

The evidence it was never automatic is in the deposited file sets — they're curated:

| File | in `release/<v>/` | on Zenodo |
|---|:-:|:-:|
| the four RDF serialisations, both flat tables, `index.html` | ✅ | ✅ |
| `APD_triples.csv`, `using_the_APD.html` | — | ✅ |
| `APD_trait_hierarchy.csv`, `APD_traits_input.csv` | ✅ | — |

A source tarball can't produce that. Now documented as a manual upload with the difference tabled, so which set gets deposited is a deliberate choice rather than inherited by accident.

**Switching to the integration was considered and rejected** (recorded in `COMMITMENTS.md`): it archives the repository tarball rather than the published outputs, and it mints its **own** concept DOI — forking the citation lineage away from `10.5281/zenodo.8040789`, the DOI in `README.md`, `index.qmd` and the paper.

## Commitments

- **C8** softened from asserting a stale version to *check by eye*. The RVA version isn't reliably machine-readable: the registry API omits it, and the page carries more than one version-shaped string (on 2026-07-29 both `2.0.18` and `2.1.1`). So it can't become a CI check, and I've stopped pretending a specific number.
- **C9** now records the two unarchived releases as an open gap.

Both are deliberately left manual — per your call, and because neither service exposes "what version is published" reliably enough for a scheduled check to be anything but false confidence.

## Also

The `austraits.build` pin bump reads the release over HTTP, so it can't run until the deploy has finished — now stated, with the check.

The checklist is reordered with the four gating steps marked `←`, and closes with a short note on what went wrong this time, since that's the most persuasive argument for following it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)