### PR TITLE
Repoint the gaps register, refresh CLAUDE.md, bump the pinned example

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,6 +24,18 @@ Process only. Anything about *what this repo contains* goes in `AGENTS.md`.
   artefacts in its own commit, separate from the refactor that caused it — `tests/testthat/test-golden.R`
   compares a fresh build against the committed artefacts, so an unintended change fails loudly.
 - **Never hand-edit `export/`, `docs/` or `release/`.** All generated. Edit `data/` and rebuild.
+  `docs/` is gitignored, so if you find yourself staging it something has gone wrong. A shipped
+  `release/<version>/` is an archive — `make release` refuses to overwrite one, and
+  `APD_FORCE_RELEASE=1` is only for a release you are still preparing.
 - **Published URLs never move.** They are what the paper, the w3id redirects and downstream packages
   resolve. `COMMITMENTS.md` C12 is the list; changing where a file sits in this repo is fine, changing
   where it is served from is not.
+- **Cutting a release? Follow [`RELEASING.md`](../RELEASING.md) step by step, in order.** Four of its
+  steps gate the ones after them, and 2.1.2 went wrong in three places by treating the list as
+  unordered. The one that bites hardest: `git merge --ff-only develop` merges your *local* `develop`,
+  so merging the release PR in the browser without pulling first publishes the commit *before* the
+  release — and it succeeds, so nothing warns you.
+- **Verify against the live service, not against the repo**, whenever the claim is about resolution or
+  publication. `scripts/check_redirects.sh` is the tool. Several things here were believed for months
+  on the strength of a plausible-looking config: 819 identifiers that did not resolve, a permalink that
+  404'd, and two Zenodo releases nobody had deposited because the docs said an integration handled it.

--- a/COMMITMENTS.md
+++ b/COMMITMENTS.md
@@ -53,10 +53,15 @@ URLs are unchanged and the repo layout is free to move again.
 
 ---
 
-## Known gaps (2026-07-27)
+## Known gaps
 
-Audited against the live service. Tracked by epic
-[#47](https://github.com/traitecoevo/APD/issues/47).
+Audited against the live service on 2026-07-27, and revised as they were fixed. Every id still on the
+register is tracked by [#59](https://github.com/traitecoevo/APD/issues/59) — the seven there are
+exactly the seven in `APD_KNOWN_GAPS`. The deposits are [#52](https://github.com/traitecoevo/APD/issues/52).
+
+> Tracking moved here from epic [#47](https://github.com/traitecoevo/APD/issues/47), which covered the
+> eight-stage build overhaul and closed once those stages shipped. The gaps outlived it, so they needed
+> an issue of their own rather than an epic kept open for them.
 
 **These are also a machine-readable register.** `APD_KNOWN_GAPS` in
 [`R/validate.R`](R/validate.R) lists every problem below that `validate_apd()` can detect, keyed by a

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ regardless of where they sit in this repository:
 
 ```
 https://traitecoevo.github.io/APD/APD_traits.csv               # latest release
-https://traitecoevo.github.io/APD/release/2.1.1/APD_traits.csv  # pinned
+https://traitecoevo.github.io/APD/release/2.1.2/APD_traits.csv  # pinned
 ```
 
 Use those rather than `raw.githubusercontent.com` paths — the repo layout can


### PR DESCRIPTION
Follow-up to #66 and the 2.1.2 release.

## Carries forward a commit that missed #66's squash

`COMMITMENTS.md` still said the known gaps are *"Tracked by epic #47"* — but #47 is now **closed**, with all eight stages shipped. Left as-is, closing the epic would have orphaned the register's only tracking link.

It now points at **[#59](https://github.com/traitecoevo/APD/issues/59)**, whose seven gap ids are exactly the seven in `APD_KNOWN_GAPS` — checked, not assumed — and at **[#52](https://github.com/traitecoevo/APD/issues/52)** for the deposits.

(I'd committed this before merging #66, but it wasn't in the squash — the PR was merged from a head that predated the push. Worth noting since `--delete-branch` also didn't remove the remote branch, so it's still there to clean up.)

## `README.md`

Pinned-URL example moves to `release/2.1.2`.

## `.claude/CLAUDE.md`

That file is about *how to work here* rather than what the repo contains, so the process lessons from cutting 2.1.2 belong in it:

- **`docs/` is gitignored** — staging it means something went wrong. And a shipped `release/<version>/` is an archive, which is what `make release`'s refusal to overwrite one is protecting; `APD_FORCE_RELEASE=1` is only for a release still being prepared.
- **Follow `RELEASING.md` in order.** Four steps gate the ones after them, and 2.1.2 went wrong in three places by treating the list as unordered. Named the one that bites hardest: **`git merge --ff-only develop` merges your *local* `develop`**, so merging the release PR in the browser without pulling first publishes the commit *before* the release — and it succeeds, so nothing warns you.
- **Verify against the live service, not the repo**, whenever the claim is about resolution or publication. Three things here were believed for months on the strength of a plausible-looking config: 819 identifiers that didn't resolve, a permalink that 404'd, and two Zenodo releases nobody had deposited.

That last one is the reason `check_redirects.sh` exists and why `redirects.yml` runs weekly.

## Companion PR

[austraits-meta#4](https://github.com/traitecoevo/austraits-meta/pull/4) records the same two findings family-wide: the archive step has an owner and isn't automatic, and the downstream pin bump can't run until APD's deploy has finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)